### PR TITLE
SSP-5 Reset cookie preferences when Nosto cookie has not been set

### DIFF
--- a/src/Decorator/Storefront/Framework/Cookie/NostoCookieProvider.php
+++ b/src/Decorator/Storefront/Framework/Cookie/NostoCookieProvider.php
@@ -8,6 +8,12 @@ use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
 
 class NostoCookieProvider implements CookieProviderInterface
 {
+    public const SHOPWARE_COOKIE_PREFERENCE_KEY = 'cookie-preference';
+
+    public const LEGACY_COOKIE_KEY = 'od-nosto-track-allow';
+
+    public const NOSTO_COOKIE_KEY = 'nosto-integration-track-allow';
+
     public function __construct(
         private readonly CookieProviderInterface $originalService,
     ) {
@@ -33,7 +39,7 @@ class NostoCookieProvider implements CookieProviderInterface
             $cookie['entries'][] = [
                 'snippet_name' => 'nosto-integration.cookie.value',
                 'snippet_description' => 'nosto-integration.cookie.description',
-                'cookie' => 'nosto-integration-track-allow',
+                'cookie' => self::NOSTO_COOKIE_KEY,
                 'expiration' => '30',
                 'value' => 1,
             ];

--- a/src/Subscriber/FrontendSubscriber.php
+++ b/src/Subscriber/FrontendSubscriber.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Nosto\NostoIntegration\Subscriber;
 
+use Nosto\NostoIntegration\Decorator\Storefront\Framework\Cookie\NostoCookieProvider;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Struct\Config;
 use Shopware\Storefront\Framework\Routing\StorefrontResponse;
 use Shopware\Storefront\Pagelet\Header\HeaderPageletLoadedEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -50,13 +53,32 @@ class FrontendSubscriber implements EventSubscriberInterface
         $response = $event->getResponse();
         $request = $event->getRequest();
 
-        if ($request->cookies->has('od-nosto-track-allow')) {
-            $cookie = Cookie::create('od-nosto-track-allow', '1', strtotime('-1 day'))
+        $this->migrateOverdoseCookie($response, $request);
+        $this->triggerCookieBanner($response, $request);
+    }
+
+    private function migrateOverdoseCookie(Response $response, Request $request): void
+    {
+        if ($request->cookies->has(NostoCookieProvider::LEGACY_COOKIE_KEY)) {
+            $cookie = Cookie::create(NostoCookieProvider::LEGACY_COOKIE_KEY, '1', strtotime('-1 day'))
                 ->withHttpOnly(false);
             $cookie->setSecureDefault($request->isSecure());
             $response->headers->setCookie($cookie);
 
-            $cookie = Cookie::create('nosto-integration-track-allow', '1', strtotime('+30 days'))
+            $cookie = Cookie::create(NostoCookieProvider::NOSTO_COOKIE_KEY, '1', strtotime('+30 days'))
+                ->withHttpOnly(false);
+            $cookie->setSecureDefault($request->isSecure());
+            $response->headers->setCookie($cookie);
+        }
+    }
+
+    private function triggerCookieBanner(Response $response, Request $request): void
+    {
+        if (
+            $request->cookies->getBoolean(NostoCookieProvider::SHOPWARE_COOKIE_PREFERENCE_KEY) &&
+            !$request->cookies->has(NostoCookieProvider::NOSTO_COOKIE_KEY)
+        ) {
+            $cookie = Cookie::create(NostoCookieProvider::SHOPWARE_COOKIE_PREFERENCE_KEY, '1', strtotime('-1 day'))
                 ->withHttpOnly(false);
             $cookie->setSecureDefault($request->isSecure());
             $response->headers->setCookie($cookie);


### PR DESCRIPTION
This is for shop users, which already accepted the cookies before the plugin was installed.