### PR TITLE
SSP-235-Add X-Nosto-Integration header with plugin version in search requests_v4

### DIFF
--- a/src/Search/Api/SearchService.php
+++ b/src/Search/Api/SearchService.php
@@ -22,6 +22,7 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Throwable;
+use Composer\InstalledVersions;
 
 class SearchService
 {
@@ -87,6 +88,14 @@ class SearchService
         AbstractRequestHandler $requestHandler,
     ): void {
         $criteria->setOffset($this->paginationService->getRequestOffset($request, $criteria->getLimit()));
+
+        // Retrieve the plugin version dynamically from InstalledVersions
+        $pluginVersion = InstalledVersions::getPrettyVersion('nosto/nosto-integration') ?? 'unknown';
+        // Set the header with plugin name and version for all search related requests
+        $request->headers->set(
+            'X-Nosto-Integration',
+            sprintf('Shopware 6 Plugin %s', $pluginVersion)
+        );
 
         $this->fetchFilters($request, $criteria, $context, $requestHandler);
         $requestHandler->fetchProducts($request, $criteria, $context);

--- a/src/Search/Api/SearchService.php
+++ b/src/Search/Api/SearchService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nosto\NostoIntegration\Search\Api;
 
+use Composer\InstalledVersions;
 use Monolog\Logger;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Search\Request\Handler\AbstractRequestHandler;
@@ -22,7 +23,6 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Throwable;
-use Composer\InstalledVersions;
 
 class SearchService
 {

--- a/src/Search/Api/SearchService.php
+++ b/src/Search/Api/SearchService.php
@@ -94,7 +94,7 @@ class SearchService
         // Set the header with plugin name and version for all search related requests
         $request->headers->set(
             'X-Nosto-Integration',
-            sprintf('Shopware 6 Plugin %s', $pluginVersion)
+            sprintf('Shopware 6 Plugin %s', $pluginVersion),
         );
 
         $this->fetchFilters($request, $criteria, $context, $requestHandler);


### PR DESCRIPTION
Adds the X-Nosto-Integration header to all search-related requests in the Shopware 6 plugin, including the plugin name and dynamically retrieved version. 