### PR TITLE
Fix the API call for analytics

### DIFF
--- a/src/Api/Controller/NostoAnalyticsTrackingController.php
+++ b/src/Api/Controller/NostoAnalyticsTrackingController.php
@@ -37,8 +37,10 @@ class NostoAnalyticsTrackingController extends AbstractController
     #[Route(
         path: "/nosto/analytics-tracking",
         name: "storefront.nosto.analytics-tracking",
-        defaults: ['XmlHttpRequest' => true],
-        methods: ["POST"]
+        defaults: [
+            'XmlHttpRequest' => true,
+        ],
+        methods: ["POST"],
     )]
     public function trackAnalytics(Request $request, SalesChannelContext $context): JsonResponse
     {

--- a/src/Api/Controller/NostoAnalyticsTrackingController.php
+++ b/src/Api/Controller/NostoAnalyticsTrackingController.php
@@ -37,7 +37,8 @@ class NostoAnalyticsTrackingController extends AbstractController
     #[Route(
         path: "/nosto/analytics-tracking",
         name: "storefront.nosto.analytics-tracking",
-        methods: ["POST"],
+        defaults: ['XmlHttpRequest' => true],
+        methods: ["POST"]
     )]
     public function trackAnalytics(Request $request, SalesChannelContext $context): JsonResponse
     {

--- a/src/Resources/app/storefront/src/js/plugin/nosto-analytics.js
+++ b/src/Resources/app/storefront/src/js/plugin/nosto-analytics.js
@@ -47,7 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             try {
-                const response = await fetch('/nosto/analytics-tracking', {
+                const apiRoute = window.router['storefront.nosto.analytics-tracking'];
+                const response = await fetch(apiRoute, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/src/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Resources/views/storefront/layout/meta.html.twig
@@ -1,0 +1,8 @@
+{% sw_extends '@Storefront/storefront/layout/meta.html.twig' %}
+{% block layout_head_javascript_router %}
+    {{ parent() }}
+    <script>
+        // Get full path for Analytics by name. Insert JS in the head.
+        window.router['storefront.nosto.analytics-tracking'] = '{{ path('storefront.nosto.analytics-tracking') }}';
+    </script>
+{% endblock %}


### PR DESCRIPTION
@iganulevics 
Note:
I added a new file (meta.html.twig) that follows all the logic for adding window.router to twig.
This could also be done by adding this js to the existing listing.html.twig, it's still the same.