### PR TITLE
ADS 5165 v5

### DIFF
--- a/src/Api/Controller/NostoAnalyticsTrackingController.php
+++ b/src/Api/Controller/NostoAnalyticsTrackingController.php
@@ -112,7 +112,8 @@ class NostoAnalyticsTrackingController extends AbstractController
                     $userAgent,
                     $appToken,
                     $account->getNostoAccount(),
-                    $request->getHost(),);
+                    $request->getHost(),
+                );
                 $metadata = new AnalyticsSearchMetadataForGraphql(
                     $data['query'] ?? null,
                     $data['resultId'] ?? vsprintf(

--- a/src/Api/Controller/NostoAnalyticsTrackingController.php
+++ b/src/Api/Controller/NostoAnalyticsTrackingController.php
@@ -11,7 +11,7 @@ use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Utils\SearchHelper;
-use Nosto\Operation\Category\AnalyticsCategoryTracking;
+use Nosto\Operation\Category\AnalyticsCategoryTrackingGraphql;
 use Nosto\Operation\Search\AnalyticsSearchTrackingGraphql;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -99,7 +99,14 @@ class NostoAnalyticsTrackingController extends AbstractController
                 return new JsonResponse(null, 204);
             }
             if ($dataSource->getType() === DataSource::CATEGORY) {
-                $tracker = new AnalyticsCategoryTracking($merchantId, $data['sessionId'], $userAgent);
+                $tracker = new AnalyticsCategoryTrackingGraphql(
+                    $merchantId,
+                    $data['sessionId'],
+                    $userAgent,
+                    $appToken,
+                    $account->getNostoAccount(),
+                    $request->getHost(),
+                );
                 $metadata = new AnalyticsCategoryMetadata(
                     $data["category"] != null ? rtrim($data["category"], "/") : null,
                     $data["categoryId"] ?? null,

--- a/src/Api/Controller/NostoAnalyticsTrackingController.php
+++ b/src/Api/Controller/NostoAnalyticsTrackingController.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\Api\Controller;
 
 use Nosto\Model\Analytics\AnalyticsCategoryMetadata;
-use Nosto\Model\Analytics\AnalyticsSearchMetadata;
+use Nosto\Model\Analytics\AnalyticsSearchMetadataForGraphql;
 use Nosto\Model\Analytics\DataSource;
 use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Utils\SearchHelper;
 use Nosto\Operation\Category\AnalyticsCategoryTracking;
-use Nosto\Operation\Search\AnalyticsSearchTracking;
+use Nosto\Operation\Search\AnalyticsSearchTrackingGraphql;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -71,6 +71,19 @@ class NostoAnalyticsTrackingController extends AbstractController
             $productId = $data['productId'];
             $userAgent = $request->headers->get('User-Agent');
             $merchantId = $this->configProvider->getAccountId($channelId, $languageId);
+            $appToken = $this->configProvider->getAppToken(
+                $context->getSalesChannelId(),
+                $context->getLanguageId(),
+            );
+            if (!$appToken) {
+                throw new Exception('No app token found for the current sales channel and language.');
+            }
+            $account = $this->accountProvider->get(
+                $context->getContext(),
+                $context->getSalesChannelId(),
+                $context->getLanguageId(),
+            );
+
             $productIdentifier = $this->configProvider->getProductIdentifier($channelId, $languageId);
             $dataSource = DataSource::fromString($data['dataSource']);
             if ($productIdentifier === ProductIdentifierOptions::PRODUCT_NUMBER) {
@@ -93,8 +106,14 @@ class NostoAnalyticsTrackingController extends AbstractController
                 );
                 $tracker->click($metadata, $productId);
             } elseif ($dataSource->getType() === DataSource::SEARCH) {
-                $tracker = new AnalyticsSearchTracking($merchantId, $data['sessionId'], $userAgent);
-                $metadata = new AnalyticsSearchMetadata(
+                $tracker = new AnalyticsSearchTrackingGraphql(
+                    $merchantId,
+                    $data['sessionId'],
+                    $userAgent,
+                    $appToken,
+                    $account->getNostoAccount(),
+                    $request->getHost(),);
+                $metadata = new AnalyticsSearchMetadataForGraphql(
                     $data['query'] ?? null,
                     $data['resultId'] ?? vsprintf(
                         '%s%s%s%s-%s%s-%s%s-%s%s-%s%s%s%s%s%s',

--- a/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -8,9 +8,10 @@ use Exception;
 use Nosto\Model\Analytics\AnalyticsCategoryMetadata;
 use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Traits\SearchResultHelper;
 use Nosto\NostoIntegration\Utils\SearchHelper;
-use Nosto\Operation\Category\AnalyticsCategoryTracking;
+use Nosto\Operation\Category\AnalyticsCategoryTrackingGraphql;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
@@ -44,6 +45,7 @@ class ProductListingRoute extends AbstractProductListingRoute
         private readonly CompositeListingProcessor $listingProcessor,
         private readonly ConfigProvider $configProvider,
         private readonly LoggerInterface $logger,
+        private readonly Account\Provider $accountProvider,
     ) {
     }
 
@@ -140,6 +142,13 @@ class ProductListingRoute extends AbstractProductListingRoute
                 $context->getSalesChannelId(),
                 $context->getLanguageId(),
             );
+            $appToken = $this->configProvider->getAppToken(
+                $context->getSalesChannelId(),
+                $context->getLanguageId(),
+            );
+            if (!$appToken) {
+                throw new Exception('No app token found for the current sales channel and language.');
+            }
             $breadcrumb = $category->getBreadcrumb();
             if (is_array($breadcrumb) && count($breadcrumb) > 1) {
                 //seems like first part of the breadcrumb is the home page which in nosto we actually don't use
@@ -162,7 +171,19 @@ class ProductListingRoute extends AbstractProductListingRoute
                 return;
             }
             $userAgent = $request->headers->get('User-Agent');
-            $tracker = new AnalyticsCategoryTracking($merchantId, $sessionId, $userAgent);
+            $account = $this->accountProvider->get(
+                $context->getContext(),
+                $context->getSalesChannelId(),
+                $context->getLanguageId(),
+            );
+            $tracker = new AnalyticsCategoryTrackingGraphql(
+                $merchantId,
+                $sessionId,
+                $userAgent,
+                $appToken,
+                $account->getNostoAccount(),
+                $request->getHost(),
+            );
             $page = $productListing->getPage();
             $metadata = new AnalyticsCategoryMetadata(
                 //Either category or categoryId are needed

--- a/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
@@ -8,6 +8,7 @@ use Exception;
 use Nosto\Model\Analytics\AnalyticsSearchMetadataForGraphql;
 use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Search\Request\Handler\SortHandlers\RecommendationSortingHandler;
 use Nosto\NostoIntegration\Search\Request\Handler\SortingHandlerService;
 use Nosto\NostoIntegration\Traits\SearchResultHelper;
@@ -33,7 +34,6 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Nosto\NostoIntegration\Model\Nosto\Account;
 
 /**
  * @see \Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute
@@ -190,8 +190,19 @@ class ProductSearchRoute extends AbstractProductSearchRoute
                 return;
             }
             $userAgent = $request->headers->get('User-Agent');
-            $account = $this->accountProvider->get($context->getContext(), $context->getSalesChannelId(), $context->getLanguageId());
-            $tracker = new AnalyticsSearchTrackingGraphql($merchantId, $sessionId, $userAgent, $appToken, $account->getNostoAccount(), $request->getHost());
+            $account = $this->accountProvider->get(
+                $context->getContext(),
+                $context->getSalesChannelId(),
+                $context->getLanguageId(),
+            );
+            $tracker = new AnalyticsSearchTrackingGraphql(
+                $merchantId,
+                $sessionId,
+                $userAgent,
+                $appToken,
+                $account->getNostoAccount(),
+                $request->getHost(),
+            );
             $page = $productListing->getPage();
             $resultId = vsprintf('%s%s%s%s-%s%s-%s%s-%s%s-%s%s%s%s%s%s', str_split(Uuid::randomHex(), 2));
             $metadata = new AnalyticsSearchMetadataForGraphql(

--- a/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\Decorator\Core\Content\Product\SalesChannel\Search;
 
 use Exception;
-use Nosto\Model\Analytics\AnalyticsSearchMetadata;
+use Nosto\Model\Analytics\AnalyticsSearchMetadataForGraphql;
 use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Search\Request\Handler\SortHandlers\RecommendationSortingHandler;
 use Nosto\NostoIntegration\Search\Request\Handler\SortingHandlerService;
 use Nosto\NostoIntegration\Traits\SearchResultHelper;
 use Nosto\NostoIntegration\Utils\SearchHelper;
-use Nosto\Operation\Search\AnalyticsSearchTracking;
+use Nosto\Operation\Search\AnalyticsSearchTrackingGraphql;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Events\ProductSearchResultEvent;
@@ -33,6 +33,7 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Nosto\NostoIntegration\Model\Nosto\Account;
 
 /**
  * @see \Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute
@@ -50,6 +51,7 @@ class ProductSearchRoute extends AbstractProductSearchRoute
         private readonly ConfigProvider $configProvider,
         private readonly LoggerInterface $logger,
         private readonly SortingHandlerService $sortingHandlerService,
+        private readonly Account\Provider $accountProvider,
     ) {
     }
 
@@ -166,6 +168,14 @@ class ProductSearchRoute extends AbstractProductSearchRoute
     ): void {
         try {
             $merchantId = $this->configProvider->getAccountId($context->getSalesChannelId(), $context->getLanguageId());
+            $appToken = $this->configProvider->getAppToken(
+                $context->getSalesChannelId(),
+                $context->getLanguageId(),
+            );
+            if (!$appToken) {
+                throw new Exception('No app token found for the current sales channel and language.');
+            }
+
             $productIdentifier = $this->configProvider->getProductIdentifier(
                 $context->getSalesChannelId(),
                 $context->getLanguageId(),
@@ -180,25 +190,26 @@ class ProductSearchRoute extends AbstractProductSearchRoute
                 return;
             }
             $userAgent = $request->headers->get('User-Agent');
-            $tracker = new AnalyticsSearchTracking($merchantId, $sessionId, $userAgent);
+            $account = $this->accountProvider->get($context->getContext(), $context->getSalesChannelId(), $context->getLanguageId());
+            $tracker = new AnalyticsSearchTrackingGraphql($merchantId, $sessionId, $userAgent, $appToken, $account->getNostoAccount(), $request->getHost());
             $page = $productListing->getPage();
             $resultId = vsprintf('%s%s%s%s-%s%s-%s%s-%s%s-%s%s%s%s%s%s', str_split(Uuid::randomHex(), 2));
-            $metadata = new AnalyticsSearchMetadata(
+            $metadata = new AnalyticsSearchMetadataForGraphql(
                 $request->get('search') ?? null,
                 $resultId,
-                //isOrganic
+                //organic
                 true,
-                //isAutoCorrect
+                //autoCorrect
                 true,
-                //isAutoComplete
+                //autoComplete
                 false,
-                //isKeyword
+                //keyword
                 false,
-                //isSorted
+                //sorted
                 $request->get('order') != null,
                 //hasResults
                 $productListing->count() > 0,
-                //isRefined
+                //refined
                 false,
             );
             //we need to know about the resultId that was used in the impression for the click analytic


### PR DESCRIPTION
sendImpresseionAnalytics updated to use AnalyticsSearchTrackingGraphql:impression
$account is read from $this->accountProvider->get($context->getContext(), $context->getSalesChannelId(), $context->getLanguageId()) and passed to AnalyticsSearchMetadataForGraphql constructor