### PR TITLE
ADS-5182 A/B testing

### DIFF
--- a/src/Resources/app/storefront/src/js/plugin/nosto-abtests.js
+++ b/src/Resources/app/storefront/src/js/plugin/nosto-abtests.js
@@ -1,0 +1,175 @@
+import CookieStorage from 'src/helper/storage/cookie-storage.helper';
+
+export default class NostoAbTests extends window.PluginBaseClass {
+    init() {
+        this.lastKnownValue = this.getNostoAbTests();
+        this.lastKnownCookie = this.getNostoCookie();
+        this.listenToLocalStorageChanges();
+        this.overrideLocalStorage();
+        this.startPolling();
+        this.startCookiePolling();
+        this.listenToPageEvents();
+
+        // Set initial cookie if localStorage data already exists
+        if (this.lastKnownValue) {
+            this.setNostoCookie(this.lastKnownValue);
+        }
+
+        // Set initial localStorage if cookie data already exists
+        if (this.lastKnownCookie) {
+            this.updateLocalStorageFromCookie();
+        }
+    }
+
+    getNostoAbTests() {
+        try {
+            const value = localStorage.getItem('nosto:abTests');
+            return value ? JSON.parse(value) : null;
+        } catch (e) {
+            console.error('Error parsing nosto:abTests from localStorage:', e);
+            return null;
+        }
+    }
+
+    getNostoCookie() {
+        try {
+            const cookieValue = CookieStorage.getItem('nosto_ab_tests');
+            return cookieValue ? JSON.parse(decodeURIComponent(cookieValue)) : null;
+        } catch (e) {
+            console.error('Error parsing nosto_ab_tests cookie:', e);
+            return null;
+        }
+    }
+
+    // Update localStorage from cookie (when PHP changes the cookie)
+    updateLocalStorageFromCookie() {
+        const cookieData = this.getNostoCookie();
+        const currentLocalStorage = this.getNostoAbTests();
+
+        // Only update if cookie data is different from localStorage
+        if (cookieData && JSON.stringify(cookieData) !== JSON.stringify(currentLocalStorage)) {
+            try {
+                // Temporarily store the original setItem to avoid triggering our override
+                const originalSetItem = localStorage.setItem;
+                localStorage.setItem = originalSetItem;
+
+                localStorage.setItem('nosto:abTests', JSON.stringify(cookieData));
+                this.lastKnownValue = cookieData;
+
+                // Restore our override
+                this.overrideLocalStorage();
+            } catch (e) {
+                console.error('Error updating localStorage from cookie:', e);
+            }
+        }
+    }
+
+    // Listen for changes from other tabs/windows
+    listenToLocalStorageChanges() {
+        window.addEventListener('storage', (e) => {
+            if (e.key === 'nosto:abTests') {
+                const newValue = e.newValue ? JSON.parse(e.newValue) : null;
+                if (newValue) {
+                    this.setNostoCookie(newValue);
+                }
+                this.lastKnownValue = newValue;
+            }
+        });
+    }
+
+    // Override localStorage.setItem to catch same-tab changes
+    overrideLocalStorage() {
+        const originalSetItem = localStorage.setItem;
+        const self = this;
+
+        localStorage.setItem = function (key, value) {
+            // Call original method first
+            originalSetItem.apply(this, arguments);
+
+            // Check if it's our target key
+            if (key === 'nosto:abTests') {
+                try {
+                    const parsedValue = JSON.parse(value);
+                    self.setNostoCookie(parsedValue);
+                    self.lastKnownValue = parsedValue;
+                } catch (e) {
+                    console.error('Error parsing nosto:abTests value:', e);
+                }
+            }
+        };
+    }
+
+    // Polling fallback to catch any missed localStorage changes
+    startPolling() {
+        this.pollInterval = setInterval(() => {
+            const currentValue = this.getNostoAbTests();
+
+            // Compare with last known value
+            if (JSON.stringify(currentValue) !== JSON.stringify(this.lastKnownValue)) {
+                if (currentValue) {
+                    this.setNostoCookie(currentValue);
+                }
+                this.lastKnownValue = currentValue;
+            }
+        }, 500); // Check every 500ms
+    }
+
+    // Monitor cookie changes (for PHP updates)
+    startCookiePolling() {
+        this.cookiePollInterval = setInterval(() => {
+            const currentCookie = this.getNostoCookie();
+
+            // Compare with last known cookie value
+            if (JSON.stringify(currentCookie) !== JSON.stringify(this.lastKnownCookie)) {
+                this.updateLocalStorageFromCookie();
+                this.lastKnownCookie = currentCookie;
+            }
+        }, 1000); // Check every 1000ms
+    }
+
+    // Listen for page events to sync immediately when user returns
+    listenToPageEvents() {
+        // When user returns to tab after server interaction
+        window.addEventListener('focus', () => {
+            this.updateLocalStorageFromCookie();
+        });
+
+        // When page becomes visible
+        document.addEventListener('visibilitychange', () => {
+            if (!document.hidden) {
+                this.updateLocalStorageFromCookie();
+            }
+        });
+    }
+
+    setNostoCookie(data) {
+        if (CookieStorage.getItem('nosto_ab_tests')) {
+            let cookie = CookieStorage.getItem('nosto_ab_tests');
+            if (encodeURIComponent(JSON.stringify(data)) === cookie) {
+                return;
+            }
+        }
+        CookieStorage.setItem(
+            'nosto_ab_tests',
+            encodeURIComponent(JSON.stringify(data)),
+            300
+        );
+        this.lastKnownCookie = data; // Update our tracked cookie value
+    }
+
+    // Cleanup method (call this when plugin is destroyed)
+    destroy() {
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+        }
+        if (this.cookiePollInterval) {
+            clearInterval(this.cookiePollInterval);
+        }
+
+        // Remove event listeners
+        window.removeEventListener('focus', this.updateLocalStorageFromCookie);
+        document.removeEventListener('visibilitychange', this.updateLocalStorageFromCookie);
+
+        // Note: We don't restore localStorage.setItem here as other instances might be using it
+    }
+}

--- a/src/Resources/app/storefront/src/main.js
+++ b/src/Resources/app/storefront/src/main.js
@@ -2,6 +2,8 @@ window.PluginManager.register('NostoPlugin', () => import('./js/plugin/nosto.plu
 window.PluginManager.register('NostoConfiguration', () => import('./js/plugin/nosto-configuration.plugin'), '[data-nosto-configuration]');
 window.PluginManager.register('NostoSearchSessionParams', () => import('./js/plugin/nosto-search-session-params'), '[data-nosto-search-session-params]');
 window.PluginManager.register('NostoAnalytics', () => import('./js/plugin/nosto-analytics'), '[data-nosto-analytics]');
+window.PluginManager.register('NostoAbTests', () => import('./js/plugin/nosto-abtests'), '[data-nosto-abtests]');
+
 window.PluginManager.override('FilterRange', () => import('./js/plugin/listing/filter-range.plugin'), '[data-filter-range]');
 window.PluginManager.override('FilterPropertySelect', () => import('./js/plugin/listing/filter-property-select.plugin'), '[data-filter-property-select]');
 window.PluginManager.register('NostoPreviewPlugin', () => import('./js/plugin/nosto-preview.plugin'), '[data-nosto-preview]');

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -30,6 +30,7 @@
             'reloadRecommendations': context.context.extensions.nostoConfig.reloadRecommendations,
         } %}
         <div hidden data-nosto-configuration="true" data-nosto-configuration-options="{{ configurationOptions|json_encode }}"></div>
+        <div hidden data-nosto-abtests="true"></div>
         <div hidden data-nosto-preview="true"></div>
     {% endblock %}
 

--- a/src/Search/Request/Handler/AbstractRequestHandler.php
+++ b/src/Search/Request/Handler/AbstractRequestHandler.php
@@ -171,11 +171,15 @@ abstract class AbstractRequestHandler
         Request $request,
         Criteria $criteria,
         ?int $limit,
-        SalesChannelContext $context
+        SalesChannelContext $context,
     ): void {
-
         $this->setPaginationParams($criteria, $searchOperation, $limit);
-        $this->setSessionParamsFromCookies($request, $searchOperation, $context->getSalesChannelId(), $context->getLanguageId());
+        $this->setSessionParamsFromCookies(
+            $request,
+            $searchOperation,
+            $context->getSalesChannelId(),
+            $context->getLanguageId(),
+        );
         $this->setAbTests($request, $searchOperation);
         $this->sortingHandlerService->handle($searchOperation, $criteria);
         $newReq = $this->shouldHandleAsNewRequest($request, $criteria);
@@ -220,9 +224,8 @@ abstract class AbstractRequestHandler
 
     protected function setAbTests(
         Request $request,
-        SearchOperation $searchOperation
-    ): void
-    {
+        SearchOperation $searchOperation,
+    ): void {
         $cookieValue = $request->cookies->get("nosto_ab_tests");
         if ($cookieValue) {
             $abTests = json_decode($cookieValue, true);
@@ -232,9 +235,8 @@ abstract class AbstractRequestHandler
 
     protected function updateAbTestsCookie(
         Request $request,
-        mixed $abTests
-    ): void
-    {
+        mixed $abTests,
+    ): void {
         if ($abTests != null) {
             $request->attributes->set(
                 'setNostoAbTestsCookie',

--- a/src/Search/Request/Handler/AbstractRequestHandler.php
+++ b/src/Search/Request/Handler/AbstractRequestHandler.php
@@ -149,6 +149,7 @@ abstract class AbstractRequestHandler
             $request,
             $criteria,
             $limit,
+            $context,
         );
 
         return $searchOperation;
@@ -170,11 +171,13 @@ abstract class AbstractRequestHandler
         Request $request,
         Criteria $criteria,
         ?int $limit,
+        SalesChannelContext $context
     ): void {
-        $this->setPaginationParams($criteria, $searchOperation, $limit);
-        $this->setSessionParamsFromCookies($request, $searchOperation, $channelId, $languageId);
-        $this->sortingHandlerService->handle($searchOperation, $criteria);
 
+        $this->setPaginationParams($criteria, $searchOperation, $limit);
+        $this->setSessionParamsFromCookies($request, $searchOperation, $context->getSalesChannelId(), $context->getLanguageId());
+        $this->setAbTests($request, $searchOperation);
+        $this->sortingHandlerService->handle($searchOperation, $criteria);
         $newReq = $this->shouldHandleAsNewRequest($request, $criteria);
         $this->filterHandler->handleFilters($request, $criteria, $searchOperation, $newReq);
     }
@@ -213,6 +216,31 @@ abstract class AbstractRequestHandler
     ): void {
         $pagination = $responseParser->getPaginationExtension($limit, $offset);
         $criteria->addExtension('nostoPagination', $pagination);
+    }
+
+    protected function setAbTests(
+        Request $request,
+        SearchOperation $searchOperation
+    ): void
+    {
+        $cookieValue = $request->cookies->get("nosto_ab_tests");
+        if ($cookieValue) {
+            $abTests = json_decode($cookieValue, true);
+            $searchOperation->setAbTests($abTests);
+        }
+    }
+
+    protected function updateAbTestsCookie(
+        Request $request,
+        mixed $abTests
+    ): void
+    {
+        if ($abTests != null) {
+            $request->attributes->set(
+                'setNostoAbTestsCookie',
+                json_encode($abTests),
+            );
+        }
     }
 
     protected function setSessionParamsFromCookies(

--- a/src/Search/Request/Handler/SearchRequestHandler.php
+++ b/src/Search/Request/Handler/SearchRequestHandler.php
@@ -20,7 +20,7 @@ class SearchRequestHandler extends AbstractRequestHandler
     ): SearchResult {
         $searchOperation = $this->getSearchOperation($request, $criteria, $context, $limit);
 
-        $searchOperation->setQuery((string)$request->query->get('search'));
+        $searchOperation->setQuery((string) $request->query->get('search'));
 
         if ($this->configProvider->isEnabledProductVisibility(
             $context->getSalesChannelId(),

--- a/src/Search/Request/Handler/SearchRequestHandler.php
+++ b/src/Search/Request/Handler/SearchRequestHandler.php
@@ -20,7 +20,7 @@ class SearchRequestHandler extends AbstractRequestHandler
     ): SearchResult {
         $searchOperation = $this->getSearchOperation($request, $criteria, $context, $limit);
 
-        $searchOperation->setQuery((string) $request->query->get('search'));
+        $searchOperation->setQuery((string)$request->query->get('search'));
 
         if ($this->configProvider->isEnabledProductVisibility(
             $context->getSalesChannelId(),
@@ -41,7 +41,7 @@ class SearchRequestHandler extends AbstractRequestHandler
             $data->data->search->products->hits = [];
             $request->attributes->set('nostoAPIResult', json_encode($data));
         }
-
+        $this->updateAbTestsCookie($request, $nostoResponse[1]->getAbTests());
         return $nostoResponse[1];
     }
 }

--- a/src/Subscriber/NostoCookieSubscriber.php
+++ b/src/Subscriber/NostoCookieSubscriber.php
@@ -78,7 +78,7 @@ class NostoCookieSubscriber implements EventSubscriberInterface
             $nostoCookieValue,
             strtotime('+1 day'),
             '/',
-           null,
+            null,
             $request->isSecure(),
             false,
             false,
@@ -87,5 +87,4 @@ class NostoCookieSubscriber implements EventSubscriberInterface
 
         $response->headers->setCookie($nostoAbCookie);
     }
-
 }

--- a/src/Subscriber/NostoCookieSubscriber.php
+++ b/src/Subscriber/NostoCookieSubscriber.php
@@ -6,6 +6,8 @@ namespace Nosto\NostoIntegration\Subscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -25,6 +27,7 @@ class NostoCookieSubscriber implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
+        $this->createAbTestsCookie($request, $response);
 
         if (!$request->attributes->has('nostoAPIResult')) {
             return;
@@ -63,4 +66,26 @@ class NostoCookieSubscriber implements EventSubscriberInterface
 
         $response->headers->setCookie($nostoCookieFilterMapping);
     }
+
+    public function createAbTestsCookie(Request $request, Response $response): void
+    {
+        if (!$request->attributes->has('setNostoAbTestsCookie')) {
+            return;
+        }
+        $nostoCookieValue = $request->attributes->get('setNostoAbTestsCookie');
+        $nostoAbCookie = new Cookie(
+            'nosto_ab_tests',
+            $nostoCookieValue,
+            strtotime('+1 day'),
+            '/',
+           null,
+            $request->isSecure(),
+            false,
+            false,
+            Cookie::SAMESITE_LAX,
+        );
+
+        $response->headers->setCookie($nostoAbCookie);
+    }
+
 }


### PR DESCRIPTION
Adding ability to create/update abTests cookie as well as create a localStorage for autocomplete template. This will pass A/B tests to search endpoints, and also update the cookie from the response. 

Will need PHP-SDK updated https://github.com/Nosto/nosto-php-sdk/pull/413 before merge