### PR TITLE
ADS-5182 Ability to work with A/B testing for search

### DIFF
--- a/src/Resources/app/storefront/src/js/plugin/nosto-abtests.js
+++ b/src/Resources/app/storefront/src/js/plugin/nosto-abtests.js
@@ -1,0 +1,175 @@
+import CookieStorage from 'src/helper/storage/cookie-storage.helper';
+
+export default class NostoAbTests extends window.PluginBaseClass {
+    init() {
+        this.lastKnownValue = this.getNostoAbTests();
+        this.lastKnownCookie = this.getNostoCookie();
+        this.listenToLocalStorageChanges();
+        this.overrideLocalStorage();
+        this.startPolling();
+        this.startCookiePolling();
+        this.listenToPageEvents();
+
+        // Set initial cookie if localStorage data already exists
+        if (this.lastKnownValue) {
+            this.setNostoCookie(this.lastKnownValue);
+        }
+
+        // Set initial localStorage if cookie data already exists
+        if (this.lastKnownCookie) {
+            this.updateLocalStorageFromCookie();
+        }
+    }
+
+    getNostoAbTests() {
+        try {
+            const value = localStorage.getItem('nosto:abTests');
+            return value ? JSON.parse(value) : null;
+        } catch (e) {
+            console.error('Error parsing nosto:abTests from localStorage:', e);
+            return null;
+        }
+    }
+
+    getNostoCookie() {
+        try {
+            const cookieValue = CookieStorage.getItem('nosto_ab_tests');
+            return cookieValue ? JSON.parse(decodeURIComponent(cookieValue)) : null;
+        } catch (e) {
+            console.error('Error parsing nosto_ab_tests cookie:', e);
+            return null;
+        }
+    }
+
+    // Update localStorage from cookie (when PHP changes the cookie)
+    updateLocalStorageFromCookie() {
+        const cookieData = this.getNostoCookie();
+        const currentLocalStorage = this.getNostoAbTests();
+
+        // Only update if cookie data is different from localStorage
+        if (cookieData && JSON.stringify(cookieData) !== JSON.stringify(currentLocalStorage)) {
+            try {
+                // Temporarily store the original setItem to avoid triggering our override
+                const originalSetItem = localStorage.setItem;
+                localStorage.setItem = originalSetItem;
+
+                localStorage.setItem('nosto:abTests', JSON.stringify(cookieData));
+                this.lastKnownValue = cookieData;
+
+                // Restore our override
+                this.overrideLocalStorage();
+            } catch (e) {
+                console.error('Error updating localStorage from cookie:', e);
+            }
+        }
+    }
+
+    // Listen for changes from other tabs/windows
+    listenToLocalStorageChanges() {
+        window.addEventListener('storage', (e) => {
+            if (e.key === 'nosto:abTests') {
+                const newValue = e.newValue ? JSON.parse(e.newValue) : null;
+                if (newValue) {
+                    this.setNostoCookie(newValue);
+                }
+                this.lastKnownValue = newValue;
+            }
+        });
+    }
+
+    // Override localStorage.setItem to catch same-tab changes
+    overrideLocalStorage() {
+        const originalSetItem = localStorage.setItem;
+        const self = this;
+
+        localStorage.setItem = function (key, value) {
+            // Call original method first
+            originalSetItem.apply(this, arguments);
+
+            // Check if it's our target key
+            if (key === 'nosto:abTests') {
+                try {
+                    const parsedValue = JSON.parse(value);
+                    self.setNostoCookie(parsedValue);
+                    self.lastKnownValue = parsedValue;
+                } catch (e) {
+                    console.error('Error parsing nosto:abTests value:', e);
+                }
+            }
+        };
+    }
+
+    // Polling fallback to catch any missed localStorage changes
+    startPolling() {
+        this.pollInterval = setInterval(() => {
+            const currentValue = this.getNostoAbTests();
+
+            // Compare with last known value
+            if (JSON.stringify(currentValue) !== JSON.stringify(this.lastKnownValue)) {
+                if (currentValue) {
+                    this.setNostoCookie(currentValue);
+                }
+                this.lastKnownValue = currentValue;
+            }
+        }, 500); // Check every 500ms
+    }
+
+    // Monitor cookie changes (for PHP updates)
+    startCookiePolling() {
+        this.cookiePollInterval = setInterval(() => {
+            const currentCookie = this.getNostoCookie();
+
+            // Compare with last known cookie value
+            if (JSON.stringify(currentCookie) !== JSON.stringify(this.lastKnownCookie)) {
+                this.updateLocalStorageFromCookie();
+                this.lastKnownCookie = currentCookie;
+            }
+        }, 1000); // Check every 1000ms
+    }
+
+    // Listen for page events to sync immediately when user returns
+    listenToPageEvents() {
+        // When user returns to tab after server interaction
+        window.addEventListener('focus', () => {
+            this.updateLocalStorageFromCookie();
+        });
+
+        // When page becomes visible
+        document.addEventListener('visibilitychange', () => {
+            if (!document.hidden) {
+                this.updateLocalStorageFromCookie();
+            }
+        });
+    }
+
+    setNostoCookie(data) {
+        if (CookieStorage.getItem('nosto_ab_tests')) {
+            let cookie = CookieStorage.getItem('nosto_ab_tests');
+            if (encodeURIComponent(JSON.stringify(data)) === cookie) {
+                return;
+            }
+        }
+        CookieStorage.setItem(
+            'nosto_ab_tests',
+            encodeURIComponent(JSON.stringify(data)),
+            300
+        );
+        this.lastKnownCookie = data; // Update our tracked cookie value
+    }
+
+    // Cleanup method (call this when plugin is destroyed)
+    destroy() {
+        if (this.pollInterval) {
+            clearInterval(this.pollInterval);
+        }
+        if (this.cookiePollInterval) {
+            clearInterval(this.cookiePollInterval);
+        }
+
+        // Remove event listeners
+        window.removeEventListener('focus', this.updateLocalStorageFromCookie);
+        document.removeEventListener('visibilitychange', this.updateLocalStorageFromCookie);
+
+        // Note: We don't restore localStorage.setItem here as other instances might be using it
+    }
+}

--- a/src/Resources/app/storefront/src/main.js
+++ b/src/Resources/app/storefront/src/main.js
@@ -2,6 +2,7 @@ window.PluginManager.register('NostoPlugin', () => import('./js/plugin/nosto.plu
 window.PluginManager.register('NostoConfiguration', () => import('./js/plugin/nosto-configuration.plugin'), '[data-nosto-configuration]');
 window.PluginManager.register('NostoSearchSessionParams', () => import('./js/plugin/nosto-search-session-params'), '[data-nosto-search-session-params]');
 window.PluginManager.register('NostoAnalytics', () => import('./js/plugin/nosto-analytics'), '[data-nosto-analytics]');
+window.PluginManager.register('NostoAbTests', () => import('./js/plugin/nosto-abtests'), '[data-nosto-abtests]');
 window.PluginManager.override('FilterRange', () => import('./js/plugin/listing/filter-range.plugin'), '[data-filter-range]');
 window.PluginManager.override('FilterPropertySelect', () => import('./js/plugin/listing/filter-property-select.plugin'), '[data-filter-property-select]');
 

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -30,6 +30,8 @@
             'reloadRecommendations': context.context.extensions.nostoConfig.reloadRecommendations,
         } %}
         <div hidden data-nosto-configuration="true" data-nosto-configuration-options="{{ configurationOptions|json_encode }}"></div>
+        <div hidden data-nosto-abtests="true"></div>
+        <div hidden data-nosto-preview="true"></div>
     {% endblock %}
 
     {% block nosto_integration_search_session_params %}

--- a/src/Search/Request/Handler/AbstractRequestHandler.php
+++ b/src/Search/Request/Handler/AbstractRequestHandler.php
@@ -176,7 +176,12 @@ abstract class AbstractRequestHandler
         $salesChannelId,
     ): void {
         $this->setPaginationParams($criteria, $searchOperation, $limit);
-        $this->setSessionParamsFromCookies($request, $searchOperation, $languageId, $salesChannelId);
+        $this->setSessionParamsFromCookies(
+            $request,
+            $searchOperation,
+            $languageId,
+            $salesChannelId,
+        );
         $this->setAbTests($request, $searchOperation);
         $this->sortingHandlerService->handle($searchOperation, $criteria);
         $newReq = $this->shouldHandleAsNewRequest($request, $criteria);
@@ -221,9 +226,8 @@ abstract class AbstractRequestHandler
 
     protected function setAbTests(
         Request $request,
-        SearchOperation $searchOperation
-    ): void
-    {
+        SearchOperation $searchOperation,
+    ): void {
         $cookieValue = $request->cookies->get("nosto_ab_tests");
         if ($cookieValue) {
             $abTests = json_decode($cookieValue, true);
@@ -233,9 +237,8 @@ abstract class AbstractRequestHandler
 
     protected function updateAbTestsCookie(
         Request $request,
-        mixed $abTests
-    ): void
-    {
+        mixed $abTests,
+    ): void {
         if ($abTests != null) {
             $request->attributes->set(
                 'setNostoAbTestsCookie',

--- a/src/Search/Request/Handler/AbstractRequestHandler.php
+++ b/src/Search/Request/Handler/AbstractRequestHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nosto\NostoIntegration\Search\Request\Handler;
 
+use GuzzleHttp\Client;
 use Monolog\Logger;
 use Nosto\Model\Signup\Account;
 use Nosto\NostoIntegration\Decorator\Storefront\Framework\Cookie\NostoCookieProvider;
@@ -17,6 +18,7 @@ use Nosto\Operation\Search\SearchOperation;
 use Nosto\Request\Api\Token;
 use Nosto\Result\Graphql\Search\SearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -147,6 +149,8 @@ abstract class AbstractRequestHandler
             $request,
             $criteria,
             $limit,
+            $languageId,
+            $channelId,
         );
 
         return $searchOperation;
@@ -168,11 +172,13 @@ abstract class AbstractRequestHandler
         Request $request,
         Criteria $criteria,
         ?int $limit,
+        $languageId,
+        $salesChannelId,
     ): void {
         $this->setPaginationParams($criteria, $searchOperation, $limit);
-        $this->setSessionParamsFromCookies($request, $searchOperation);
+        $this->setSessionParamsFromCookies($request, $searchOperation, $languageId, $salesChannelId);
+        $this->setAbTests($request, $searchOperation);
         $this->sortingHandlerService->handle($searchOperation, $criteria);
-
         $newReq = $this->shouldHandleAsNewRequest($request, $criteria);
         $this->filterHandler->handleFilters($request, $criteria, $searchOperation, $newReq);
     }
@@ -213,11 +219,113 @@ abstract class AbstractRequestHandler
         $criteria->addExtension('nostoPagination', $pagination);
     }
 
-    protected function setSessionParamsFromCookies(Request $request, SearchOperation $searchOperation): void
+    protected function setAbTests(
+        Request $request,
+        SearchOperation $searchOperation
+    ): void
     {
-        if ($sessionParamsString = $request->cookies->get('nosto-search-session-params')) {
-            $sessionParams = json_decode($sessionParamsString, true);
-            $searchOperation->setSessionParams(empty($sessionParams) ? null : $sessionParams);
+        $cookieValue = $request->cookies->get("nosto_ab_tests");
+        if ($cookieValue) {
+            $abTests = json_decode($cookieValue, true);
+            $searchOperation->setAbTests($abTests);
+        }
+    }
+
+    protected function updateAbTestsCookie(
+        Request $request,
+        mixed $abTests
+    ): void
+    {
+        if ($abTests != null) {
+            $request->attributes->set(
+                'setNostoAbTestsCookie',
+                json_encode($abTests),
+            );
+        }
+    }
+
+    protected function setSessionParamsFromCookies(
+        Request $request,
+        SearchOperation $searchOperation,
+        $channelId,
+        $languageId,
+    ): void {
+        $cookieName = 'nosto-search-session-params';
+        $cookieValue = $request->cookies->get($cookieName);
+
+        if (!$cookieValue) {
+            try {
+                $nostoAccountId = (new Account(
+                    $this->configProvider->getAccountId($channelId, $languageId),
+                ))->getName();
+
+                $isSearch = str_contains($request->getPathInfo(), '/search');
+                $isCategory = $request->attributes->has('navigationId');
+
+                $message = [
+                    'url' => $request->getUri(),
+                    'response_mode' => 'HTML',
+                    'referrer' => $request->headers->get('referer'),
+                    'page_type' => $isSearch ? 'search' : ($isCategory ? 'category' : 'other'),
+                    'elements' => [],
+                    'cart' => [],
+                    'events' => [],
+                ];
+
+                foreach ($request->query->all() as $value) {
+                    if (!empty($value)) {
+                        $message['events'][] = ['ec', $value];
+                    }
+                }
+
+                $clientId = $request->cookies->get('2c_cId') ?? Uuid::randomHex();
+
+                $queryParams = [
+                    'c' => $clientId,
+                    'm' => $nostoAccountId,
+                    'message' => json_encode($message),
+                    'skipEvents' => 'true',
+                ];
+
+                $response = (new Client())->get('https://connect.nosto.com/ev1?' . http_build_query($queryParams), [
+                    'headers' => [
+                        'User-Agent' => $request->headers->get('User-Agent'),
+                        'Accept' => 'application/json',
+                        'Accept-Language' => $request->headers->get('Accept-Language'),
+                        'Referer' => $request->headers->get('referer'),
+                        'Cookie' => $request->headers->get('cookie'),
+                    ],
+                ]);
+
+                $responseData = json_decode($response->getBody()->getContents(), true);
+
+                $segments = array_column($responseData['se']['active_segments'] ?? [], 'id');
+
+                $categories = array_map(
+                    fn ($cat) => [
+                        'field' => 'affinities.categories',
+                        'value' => [$cat['name']],
+                        'weight' => $cat['score'],
+                    ],
+                    $responseData['af']['top_categories'] ?? [],
+                );
+
+                $sessionParams = [
+                    'segments' => $segments,
+                    'products' => [
+                        'personalizationBoost' => $categories,
+                    ],
+                ];
+
+                $searchOperation->setSessionParams($sessionParams);
+            } catch (\Throwable $e) {
+                $this->logger->error('Nosto ev1 call failed: ' . $e->getMessage());
+            }
+        }
+
+        if ($cookieValue = $request->cookies->get($cookieName)) {
+            $sessionParams = json_decode($cookieValue, true);
+            $searchOperation->setSessionParams(!empty($sessionParams) ? $sessionParams : null);
         }
     }
 

--- a/src/Search/Request/Handler/SearchRequestHandler.php
+++ b/src/Search/Request/Handler/SearchRequestHandler.php
@@ -20,7 +20,7 @@ class SearchRequestHandler extends AbstractRequestHandler
     ): SearchResult {
         $searchOperation = $this->getSearchOperation($request, $criteria, $context, $limit);
 
-        $searchOperation->setQuery((string) $request->query->get('search'));
+        $searchOperation->setQuery((string)$request->query->get('search'));
 
         if ($this->configProvider->isEnabledProductVisibility(
             $context->getSalesChannelId(),
@@ -39,7 +39,7 @@ class SearchRequestHandler extends AbstractRequestHandler
         if (empty($request->cookies->get('nostoCookieFilter'))) {
             $request->attributes->set('nostoAPIResult', $nostoResponse[0]);
         }
-
+        $this->updateAbTestsCookie($request, $nostoResponse[1]->getAbTests());
         return $nostoResponse[1];
     }
 }

--- a/src/Search/Request/Handler/SearchRequestHandler.php
+++ b/src/Search/Request/Handler/SearchRequestHandler.php
@@ -20,7 +20,7 @@ class SearchRequestHandler extends AbstractRequestHandler
     ): SearchResult {
         $searchOperation = $this->getSearchOperation($request, $criteria, $context, $limit);
 
-        $searchOperation->setQuery((string)$request->query->get('search'));
+        $searchOperation->setQuery((string) $request->query->get('search'));
 
         if ($this->configProvider->isEnabledProductVisibility(
             $context->getSalesChannelId(),

--- a/src/Subscriber/NostoCookieSubscriber.php
+++ b/src/Subscriber/NostoCookieSubscriber.php
@@ -78,7 +78,7 @@ class NostoCookieSubscriber implements EventSubscriberInterface
             $nostoCookieValue,
             strtotime('+1 day'),
             '/',
-           null,
+            null,
             $request->isSecure(),
             false,
             false,
@@ -87,5 +87,4 @@ class NostoCookieSubscriber implements EventSubscriberInterface
 
         $response->headers->setCookie($nostoAbCookie);
     }
-
 }

--- a/src/Subscriber/NostoCookieSubscriber.php
+++ b/src/Subscriber/NostoCookieSubscriber.php
@@ -6,6 +6,8 @@ namespace Nosto\NostoIntegration\Subscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -25,6 +27,7 @@ class NostoCookieSubscriber implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         $response = $event->getResponse();
+        $this->createAbTestsCookie($request, $response);
 
         if (!$request->attributes->has('nostoAPIResult')) {
             return;
@@ -63,4 +66,26 @@ class NostoCookieSubscriber implements EventSubscriberInterface
 
         $response->headers->setCookie($nostoCookieFilterMapping);
     }
+
+    public function createAbTestsCookie(Request $request, Response $response): void
+    {
+        if (!$request->attributes->has('setNostoAbTestsCookie')) {
+            return;
+        }
+        $nostoCookieValue = $request->attributes->get('setNostoAbTestsCookie');
+        $nostoAbCookie = new Cookie(
+            'nosto_ab_tests',
+            $nostoCookieValue,
+            strtotime('+1 day'),
+            '/',
+           null,
+            $request->isSecure(),
+            false,
+            false,
+            Cookie::SAMESITE_LAX,
+        );
+
+        $response->headers->setCookie($nostoAbCookie);
+    }
+
 }


### PR DESCRIPTION
Adding ability to create/update abTests cookie as well as create a localStorage for autocomplete template. This will pass A/B tests to search endpoints, and also update the cookie from the response.

Will need PHP-SDK updated https://github.com/Nosto/nosto-php-sdk/pull/413 before merge