### PR TITLE
NS-12731_v3 Facet filters are not being applied

### DIFF
--- a/src/Search/Request/Handler/AbstractRequestHandler.php
+++ b/src/Search/Request/Handler/AbstractRequestHandler.php
@@ -97,9 +97,10 @@ abstract class AbstractRequestHandler
     ): void {
         $filterCookie = $request->cookies->get('nostoCookieFilter');
         $filterMappingCookie = $request->cookies->get(NostoCookieProvider::NOSTO_FILTERS_KEY);
+        $isInitialSearch = $request->attributes->get('isInitialSearch');
 
         // USE NOSTO RESPONSE FILTERS
-        if (!$filterCookie || !$filterMappingCookie) {
+        if ($isInitialSearch || !$filterCookie || !$filterMappingCookie) {
             $filters = $this->parseFiltersFromResponse($response);
             $filterMapping = $this->parseFilterMappingFromResponse($response);
         } else {

--- a/src/Search/Request/Handler/FilterHandler.php
+++ b/src/Search/Request/Handler/FilterHandler.php
@@ -169,7 +169,7 @@ class FilterHandler
             return;
         }
 
-        if (in_array($filterId, $nostoFilters, true)) {
+        if (array_key_exists($filterId, $nostoFilters)) {
             $this->handlePropertyFilter($filterField, $filterValue, $searchOperation);
         }
     }

--- a/src/Search/Request/Handler/NavigationRequestHandler.php
+++ b/src/Search/Request/Handler/NavigationRequestHandler.php
@@ -55,12 +55,13 @@ class NavigationRequestHandler extends AbstractRequestHandler
 
         $searchOperation->setResponseTimeout(3);
         $searchOperation->setConnectTimeout(3);
-
         $nostoResponse = $searchOperation->executeSw();
-        if (empty($request->cookies->get('nostoCookieFilter'))) {
+
+        if (empty($searchOperation->getVariables()['filter'])) {
             $data = json_decode($nostoResponse[0]);
             $data->data->search->products->hits = [];
             $request->attributes->set('nostoAPIResult', json_encode($data));
+            $request->attributes->set('isInitialSearch', true);
         }
         $this->updateAbTestsCookie($request, $nostoResponse[1]->getAbTests());
         return $nostoResponse[1];

--- a/src/Search/Request/Handler/SearchRequestHandler.php
+++ b/src/Search/Request/Handler/SearchRequestHandler.php
@@ -36,11 +36,13 @@ class SearchRequestHandler extends AbstractRequestHandler
         $searchOperation->setConnectTimeout(3);
         $nostoResponse = $searchOperation->executeSw();
 
-        if (empty($request->cookies->get('nostoCookieFilter'))) {
+        if (empty($searchOperation->getVariables()['filter'])) {
             $data = json_decode($nostoResponse[0]);
             $data->data->search->products->hits = [];
             $request->attributes->set('nostoAPIResult', json_encode($data));
+            $request->attributes->set('isInitialSearch', true);
         }
+
         $this->updateAbTestsCookie($request, $nostoResponse[1]->getAbTests());
         return $nostoResponse[1];
     }


### PR DESCRIPTION
-Fix bug in checking existence of filterId in nostoFilters
-Add initial search flag to distinguish between an initial search result and a filtered searched result
-If its an initial search, update nostoAPIResult to have all possible filters in nostoCookieFilter
-If its an initial search read all possible filters from response else read them from nostoCookieFilter