### PR TITLE
Fixes for Order tracking 6.7

### DIFF
--- a/src/EventListener/OrderWrittenEventListener.php
+++ b/src/EventListener/OrderWrittenEventListener.php
@@ -8,11 +8,13 @@ use Nosto\NostoIntegration\Async\EventsWriter;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\System\StateMachine\Event\StateMachineStateChangeEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class OrderWrittenEventListener implements EventSubscriberInterface
 {
     public function __construct(
         private readonly EventsWriter $eventsWriter,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -29,10 +31,13 @@ class OrderWrittenEventListener implements EventSubscriberInterface
 
     public function onCheckoutOrderPlaced(CheckoutOrderPlacedEvent $event): void
     {
+        $cookieValue = $this->requestStack->getCurrentRequest()?->cookies->get('2c_cId');
+
         $this->eventsWriter->writeEvent(
             $this->eventsWriter::ORDER_ENTITY_PLACED_NAME,
             $event->getOrder()->getId(),
             $event->getContext(),
+            $cookieValue
         );
     }
 

--- a/src/EventListener/OrderWrittenEventListener.php
+++ b/src/EventListener/OrderWrittenEventListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\EventListener;
 
 use Nosto\NostoIntegration\Async\EventsWriter;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\System\StateMachine\Event\StateMachineStateChangeEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -15,6 +16,7 @@ class OrderWrittenEventListener implements EventSubscriberInterface
     public function __construct(
         private readonly EventsWriter $eventsWriter,
         private readonly RequestStack $requestStack,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -32,12 +34,21 @@ class OrderWrittenEventListener implements EventSubscriberInterface
     public function onCheckoutOrderPlaced(CheckoutOrderPlacedEvent $event): void
     {
         $cookieValue = $this->requestStack->getCurrentRequest()?->cookies->get('2c_cId');
-
+        if (!$cookieValue) {
+            $this->logger->error(
+                'Skipping ORDER_ENTITY_PLACED event because 2c_cId cookie is missing',
+                [
+                    'orderId' => $event->getOrder()->getId(),
+                    'orderNumber' => $event->getOrder()->getOrderNumber(),
+                ],
+            );
+            return;
+        }
         $this->eventsWriter->writeEvent(
             $this->eventsWriter::ORDER_ENTITY_PLACED_NAME,
             $event->getOrder()->getId(),
             $event->getContext(),
-            $cookieValue
+            $cookieValue,
         );
     }
 

--- a/src/Model/Nosto/Entity/Order/Builder.php
+++ b/src/Model/Nosto/Entity/Order/Builder.php
@@ -10,9 +10,11 @@ use Nosto\Model\Order\Order as NostoOrder;
 use Nosto\Model\Order\OrderStatus;
 use Nosto\NostoException;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Order\Event\NostoOrderBuiltEvent;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Order\Item\Builder as NostoOrderItemBuilder;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Person\BuilderInterface as NostoBuyerBuilderInterface;
+use Nosto\NostoIntegration\Model\Nosto\Entity\Product\ProductProviderInterface;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -30,6 +32,8 @@ class Builder
         private readonly SystemConfigService $systemConfigService,
         private readonly ConfigProvider $configProvider,
         private readonly EntityRepository $productRepository,
+        private readonly ProductHelper $productHelper,
+        private readonly ProductProviderInterface $productProvider,
     ) {
     }
 
@@ -70,6 +74,8 @@ class Builder
                     $context,
                     $this->configProvider,
                     $this->systemConfigService,
+                    $this->productHelper,
+                    $this->productProvider
                 );
                 $nostoOrder->addPurchasedItems($nostoItem);
             }

--- a/src/Model/Nosto/Entity/Order/Builder.php
+++ b/src/Model/Nosto/Entity/Order/Builder.php
@@ -75,7 +75,7 @@ class Builder
                     $this->configProvider,
                     $this->systemConfigService,
                     $this->productHelper,
-                    $this->productProvider
+                    $this->productProvider,
                 );
                 $nostoOrder->addPurchasedItems($nostoItem);
             }

--- a/src/Model/Nosto/Entity/Order/Item/Builder.php
+++ b/src/Model/Nosto/Entity/Order/Item/Builder.php
@@ -46,7 +46,12 @@ class Builder
         ) === ProductIdentifierOptions::PRODUCT_ID) {
             $skuId = $item->getProductId();
         }
-        $productTaggingHelper = new ProductTaggingHelper($systemConfigService, $configProvider, $productProvider, $productHelper);
+        $productTaggingHelper = new ProductTaggingHelper(
+            $systemConfigService,
+            $configProvider,
+            $productProvider,
+            $productHelper,
+        );
         $productId = $productTaggingHelper->findProductId($context, $parentProduct, $product);
 
         $nostoItem = new NostoLineItem();

--- a/src/Model/Nosto/Entity/Order/Item/Builder.php
+++ b/src/Model/Nosto/Entity/Order/Item/Builder.php
@@ -8,6 +8,8 @@ use Exception;
 use Nosto\Model\Cart\LineItem as NostoLineItem;
 use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper;
+use Nosto\NostoIntegration\Model\Nosto\Entity\Product\ProductProviderInterface;
 use Nosto\NostoIntegration\Utils\ProductTaggingHelper;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Content\Product\ProductEntity;
@@ -26,12 +28,14 @@ class Builder
         SalesChannelContext $context,
         ConfigProvider $configProvider,
         SystemConfigService $systemConfigService,
+        ProductHelper $productHelper,
+        ProductProviderInterface $productProvider,
     ): NostoLineItem {
         $criteria = new Criteria([$item->getProductId()]);
         $criteria->addAssociation('children');
         /** @var ProductEntity|null $product */
         $product = $productRepository->search($criteria, $context->getContext())->first();
-        $criteria = new Criteria([$product->getParentId()]);
+        $criteria = new Criteria([$product->getParentId() != null ? $product->getParentId() : $product->getId()]);
         $criteria->addAssociation('children');
         /** @var ProductEntity|null $parentProduct */
         $parentProduct = $productRepository->search($criteria, $context->getContext())->first();
@@ -42,7 +46,7 @@ class Builder
         ) === ProductIdentifierOptions::PRODUCT_ID) {
             $skuId = $item->getProductId();
         }
-        $productTaggingHelper = new ProductTaggingHelper($systemConfigService, $configProvider);
+        $productTaggingHelper = new ProductTaggingHelper($systemConfigService, $configProvider, $productProvider, $productHelper);
         $productId = $productTaggingHelper->findProductId($context, $parentProduct, $product);
 
         $nostoItem = new NostoLineItem();

--- a/src/Model/Operation/EntityChangelogSyncHandler.php
+++ b/src/Model/Operation/EntityChangelogSyncHandler.php
@@ -78,7 +78,7 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
         $iterator = new RepositoryIterator($this->entityChangelogRepository, $context, $criteria);
 
         while (($events = $iterator->fetch()) !== null) {
-            $ids = $entityType === ProductDefinition::ENTITY_NAME || $entityType === 'order_placed'?
+            $ids = $entityType === ProductDefinition::ENTITY_NAME || $entityType === 'order_placed' ?
                 $events->reduce(static function (array $result, ChangelogEntity $event): array {
                     $result[$event->getEntityId()] = $event->getProductNumber();
                     return $result;

--- a/src/Model/Operation/EntityChangelogSyncHandler.php
+++ b/src/Model/Operation/EntityChangelogSyncHandler.php
@@ -78,7 +78,7 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
         $iterator = new RepositoryIterator($this->entityChangelogRepository, $context, $criteria);
 
         while (($events = $iterator->fetch()) !== null) {
-            $ids = $entityType === ProductDefinition::ENTITY_NAME ?
+            $ids = $entityType === ProductDefinition::ENTITY_NAME || $entityType === 'order_placed'?
                 $events->reduce(static function (array $result, ChangelogEntity $event): array {
                     $result[$event->getEntityId()] = $event->getProductNumber();
                     return $result;

--- a/src/Model/Operation/OrderSyncHandler.php
+++ b/src/Model/Operation/OrderSyncHandler.php
@@ -112,8 +112,12 @@ class OrderSyncHandler implements JobHandlerInterface
         return $this->orderRepository->search($criteria, $context)->getEntities();
     }
 
-    private function sendNewOrder(OrderEntity $order, Account $account, SalesChannelContext $context, ?string $sessionId): void
-    {
+    private function sendNewOrder(
+        OrderEntity $order,
+        Account $account,
+        SalesChannelContext $context,
+        ?string $sessionId,
+    ): void {
         if (!$sessionId) {
             return;
         }

--- a/src/Model/Operation/OrderSyncHandler.php
+++ b/src/Model/Operation/OrderSyncHandler.php
@@ -65,9 +65,14 @@ class OrderSyncHandler implements JobHandlerInterface
     private function doOperation(Account $account, SalesChannelContext $context, object $message): JobResult
     {
         $result = new JobResult();
-        foreach ($this->getOrders($context->getContext(), $message->getNewOrderIds()) as $order) {
+        $orderIds = $message->getNewOrderIds();
+        if (empty($orderIds)) {
+            return new JobResult();
+        }
+        foreach ($this->getOrders($context->getContext(), $orderIds) as $order) {
             try {
-                $this->sendNewOrder($order, $account, $context);
+                $sessionId = $orderIds[$order->getId()] ?? null;
+                $this->sendNewOrder($order, $account, $context, $sessionId);
             } catch (Throwable $e) {
                 $result->addError($e);
             }
@@ -85,6 +90,14 @@ class OrderSyncHandler implements JobHandlerInterface
 
     private function getOrders(Context $context, array $orderIds): EntityCollection
     {
+        $ids = [];
+        if (array_is_list($orderIds)) {
+            $ids = $orderIds;
+        } else {
+            foreach ($orderIds as $entityId => $productId) {
+                $ids[] = $entityId;
+            }
+        }
         $criteria = new Criteria();
         $criteria->addAssociation('stateMachineState');
         $criteria->addAssociation('orderCustomer');
@@ -93,25 +106,27 @@ class OrderSyncHandler implements JobHandlerInterface
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('transactions.paymentMethod');
         $criteria->addAssociation('lineItems.orderLineItem.product');
-        $criteria->addFilter(new EqualsAnyFilter('id', $orderIds));
+        $criteria->addFilter(new EqualsAnyFilter('id', $ids));
         $criteria->addFilter(new EqualsFilter('languageId', $context->getLanguageId()));
         $this->eventDispatcher->dispatch(new NostoOrderCriteriaEvent($criteria, $context));
         return $this->orderRepository->search($criteria, $context)->getEntities();
     }
 
-    private function sendNewOrder(OrderEntity $order, Account $account, SalesChannelContext $context): void
+    private function sendNewOrder(OrderEntity $order, Account $account, SalesChannelContext $context, ?string $sessionId): void
     {
+        if (!$sessionId) {
+            return;
+        }
         $nostoOrder = $this->nostoOrderbuilder->build(
             $order,
             $context,
         );
-        $nostoCustomerId = $order->getOrderCustomer()->getCustomerId();
-        $nostoCustomerIdentifier = AbstractGraphQLOperation::IDENTIFIER_BY_REF;
+        $nostoCustomerIdentifier = AbstractGraphQLOperation::IDENTIFIER_BY_CID;
         $operation = new OrderCreate(
             $nostoOrder,
             $account->getNostoAccount(),
             $nostoCustomerIdentifier,
-            $nostoCustomerId,
+            $sessionId,
         );
         $this->eventDispatcher->dispatch(new BeforeOrderCreatedEvent($operation, $context->getContext()));
         $operation->execute();

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -161,6 +161,8 @@
             <argument key="$buyerBuilder" type="service"
                       id="Nosto\NostoIntegration\Model\Nosto\Entity\Order\Buyer\Builder"/>
             <argument key="$productRepository" type="service" id="product.repository"/>
+            <argument key="$productProvider" type="service"
+                      id="Nosto\NostoIntegration\Model\Nosto\Entity\Product\CachedProvider"/>
         </service>
 
         <service id="Nosto\NostoIntegration\Model\Nosto\Entity\Order\Buyer\Builder"/>


### PR DESCRIPTION
  ## Issue
  - Order tracking via plugin was sending orders with ref and customer id, which means if customer wasn't logged in order would be stored without being linked to the session. This would influence analytics not working as expected.
  
  ## Summary
  - capture the `2c_cId` cookie during checkout and forward it through `EventsWriter` so order sync jobs receive the browser session id alongside the order id
  - update `OrderSyncHandler` to accept both scalar and key/value payloads from the changelog, enrich GraphQL order creation with the captured session id, and fall back safely when no id is present
  - wire the additional dependencies needed for building order items (product helper/provider) and adjust product id lookups so parent SKUs resolve correctly

  ## Testing
  - Made multiple orders locally, and now both GraphQL and Browser show on Product Intelligence
<img width="1635" height="114" alt="Screenshot 2025-10-28 at 9 54 28" src="https://github.com/user-attachments/assets/b29355af-e986-43c4-b4ac-cfa80ad4c396" />
