### PR TITLE
NS-13081 fixing the issue with Nosto settings page not showing all fe…

### DIFF
--- a/src/Resources/app/administration/src/module/nosto/components/nosto-integration-features-flags/nosto-integration-features-flags.html.twig
+++ b/src/Resources/app/administration/src/module/nosto/components/nosto-integration-features-flags/nosto-integration-features-flags.html.twig
@@ -148,22 +148,6 @@
             </sw-inherit-wrapper>
         {% endblock %}
 
-        {% block nosto_integration_sync_batch_size %}
-            <sw-number-field
-                name="syncBatchSize"
-                :label="$tc('nosto.configuration.featuresFlags.syncBatchSize')"
-                :help-text="$tc('nosto.configuration.featuresFlags.syncBatchSizeHelpText')"
-                :disabled="configKey !== null"
-                :value="configKey === null ? currentConfig['syncBatchSize'] : configs['null']['syncBatchSize']"
-                :min="1"
-                :max="150"
-                :allow-empty="false"
-                number-type="int"
-                :step="1"
-                @update:value="configKey === null && onUpdateValue('syncBatchSize', $event)"
-            />
-        {% endblock %}
-
         {% block nosto_integration_feature_variations %}
             <sw-inherit-wrapper
                     v-model="actualConfigData['variations']"
@@ -565,17 +549,17 @@
 
         {% block nosto_integration_feature_product_visibility %}
             <sw-inherit-wrapper
-                v-model="actualConfigData['enableProductVisibility']"
-                :inheritedValue="configKey === null ? null : allConfigs['null']['enableProductVisibility']"
+                    v-model="actualConfigData['enableProductVisibility']"
+                    :inheritedValue="configKey === null ? null : allConfigs['null']['enableProductVisibility']"
             >
                 <template #content="props">
                     <sw-switch-field
-                        :map-inheritance="props"
-                        :label="$tc('nosto.configuration.featuresFlags.enableProductVisibility.label')"
-                        :help-text="$tc('nosto.configuration.featuresFlags.enableProductVisibility.helpText')"
-                        :disabled="props.isInherited"
-                        :value="props.currentValue"
-                        @change="props.updateCurrentValue"
+                            :map-inheritance="props"
+                            :label="$tc('nosto.configuration.featuresFlags.enableProductVisibility.label')"
+                            :help-text="$tc('nosto.configuration.featuresFlags.enableProductVisibility.helpText')"
+                            :disabled="props.isInherited"
+                            :value="props.currentValue"
+                            @change="props.updateCurrentValue"
                     />
                 </template>
             </sw-inherit-wrapper>
@@ -583,17 +567,17 @@
 
         {% block nosto_integration_feature_tagging_skus %}
             <sw-inherit-wrapper
-                v-model="actualConfigData['enableTaggingForAllSkus']"
-                :inheritedValue="configKey === null ? null : allConfigs['null']['enableTaggingForAllSkus']"
+                    v-model="actualConfigData['enableTaggingForAllSkus']"
+                    :inheritedValue="configKey === null ? null : allConfigs['null']['enableTaggingForAllSkus']"
             >
                 <template #content="props">
                     <sw-switch-field
-                        :map-inheritance="props"
-                        :label="$tc('nosto.configuration.featuresFlags.enableTaggingForAllSkus.label')"
-                        :help-text="$tc('nosto.configuration.featuresFlags.enableTaggingForAllSkus.helpText')"
-                        :disabled="props.isInherited"
-                        :value="props.currentValue"
-                        @change="props.updateCurrentValue"
+                            :map-inheritance="props"
+                            :label="$tc('nosto.configuration.featuresFlags.enableTaggingForAllSkus.label')"
+                            :help-text="$tc('nosto.configuration.featuresFlags.enableTaggingForAllSkus.helpText')"
+                            :disabled="props.isInherited"
+                            :value="props.currentValue"
+                            @change="props.updateCurrentValue"
                     />
                 </template>
             </sw-inherit-wrapper>
@@ -601,20 +585,46 @@
 
         {% block nosto_integration_feature_fallback_mechanism %}
             <sw-inherit-wrapper
-                v-model="actualConfigData['enableFallbackMechanism']"
-                :inheritedValue="configKey === null ? null : allConfigs['null']['enableFallbackMechanism']"
+                    v-model="actualConfigData['enableFallbackMechanism']"
+                    :inheritedValue="configKey === null ? null : allConfigs['null']['enableFallbackMechanism']"
             >
                 <template #content="props">
                     <sw-switch-field
-                        :map-inheritance="props"
-                        :label="$tc('nosto.configuration.featuresFlags.enableFallbackMechanism.label')"
-                        :help-text="$tc('nosto.configuration.featuresFlags.enableFallbackMechanism.helpText')"
-                        :disabled="props.isInherited"
-                        :value="props.currentValue"
-                        @change="props.updateCurrentValue"
+                            :map-inheritance="props"
+                            :label="$tc('nosto.configuration.featuresFlags.enableFallbackMechanism.label')"
+                            :help-text="$tc('nosto.configuration.featuresFlags.enableFallbackMechanism.helpText')"
+                            :disabled="props.isInherited"
+                            :value="props.currentValue"
+                            @change="props.updateCurrentValue"
                     />
                 </template>
             </sw-inherit-wrapper>
+        {% endblock %}
+        {% block nosto_integration_sync_batch_size %}
+        <sw-inherit-wrapper
+                v-if="configKey === null"
+                v-model="actualConfigData['syncBatchSize']"
+                :inheritedValue="configKey === null ? null : allConfigs['null']['syncBatchSize']"
+        >
+            <template #content="props">
+                <sw-number-field
+                        name="syncBatchSize"
+                        labelProperty="label"
+                        valueProperty="value"
+                        :isInherited="props.isInherited"
+                        :disabled="props.isInherited"
+                        show-clearable-button
+                        :value="props.currentValue"
+                        @change="props.updateCurrentValue"
+                        :label="$tc('nosto.configuration.featuresFlags.syncBatchSize')"
+                        number-type="int"
+                        :allow-empty="false"
+                        :min="1"
+                        :max="150"
+                        :step="1"
+                />
+            </template>
+        </sw-inherit-wrapper>
         {% endblock %}
     </sw-card>
 {% endblock %}


### PR DESCRIPTION
 ## Summary

  - replace the Shopware 6.6-style sw-number-field usage for syncBatchSize with the 6.5-compatible sw-inherit-wrapper
  - limit editing of the batch size to the global configuration scope so sales channels always inherit the same value
  - keep the surrounding field layout intact while normalizing indentation introduced by the new wrapper

  ## Testing

  - Open Administration → Extensions → Nosto.
  - Confirm the batch size field is editable in the “All sales channels” scope.
  - Switch to any specific sales channel and verify the field disappears (value is inherited automatically).