### PR TITLE
NS-13117-develop

### DIFF
--- a/src/Resources/app/administration/src/module/nosto/components/nosto-integration-account-general/nosto-integration-account-general.html.twig
+++ b/src/Resources/app/administration/src/module/nosto/components/nosto-integration-account-general/nosto-integration-account-general.html.twig
@@ -16,7 +16,8 @@
 
             {% block nosto_integration_account_api_validate %}
                 <sw-button-process
-                    variant="ghost"
+                    variant="primary"
+                    ghost=true
                     class="validate-btn"
                     :isLoading="apiValidationInProgress"
                     :processSuccess="false"

--- a/src/Resources/app/administration/src/module/nosto/pages/nosto-job-listing/nosto-job-listing.html.twig
+++ b/src/Resources/app/administration/src/module/nosto/pages/nosto-job-listing/nosto-job-listing.html.twig
@@ -13,7 +13,8 @@
                     @click="onCancelRunningFullProductSyncJob"
                     :isLoading="isLoading"
                     class="nosto-integration-detail__smart-bar-edit-button"
-                    variant="ghost"
+                    variant="primary"
+                    ghost=true
                     :title="cancelRunningFullProductSyncJobActionTitle"
             >
                 {{ $tc('nosto.listing.cancelRunningFullProductSyncJobActionLabel') }}

--- a/src/Resources/views/storefront/component/pagination.html.twig
+++ b/src/Resources/views/storefront/component/pagination.html.twig
@@ -5,8 +5,8 @@
         {{ parent() }}
     {% else %}
         {% if not (searchResult.criteria.extensions.nostoPagination) %}
-            {% set currentPage = ((criteria.offset + 1) / criteria.limit )|round(0, 'ceil') %}
-            {% set totalPages = (entities.total / criteria.limit)|round(0, 'ceil') %}
+            {% set currentPage = entities.page %}
+            {% set totalPages = (entities.total / (entities.limit ?: 1))|round(0, 'ceil') %}
         {% else %}
             {% set currentPage = ((searchResult.criteria.extensions.nostoPagination.offset + 1) / searchResult.criteria.extensions.nostoPagination.limit )|round(0, 'ceil') %}
             {% set totalPages = (searchResult.criteria.extensions.nostoPagination.total / searchResult.criteria.extensions.nostoPagination.limit)|round(0, 'ceil') %}


### PR DESCRIPTION
1: update pagination for Shopware 6.7
- currentPage should use entities.page instead of criteria.offset
- replaced deprecated criteria.limit with entities.limit

2: "ghost" variant removed from sw-button-process for Shopware 6.7 so we should use variant="primary" ghost=true instead