### PR TITLE
Explicitly telling json_decode to decode to object

### DIFF
--- a/src/Utils/SearchHelper.php
+++ b/src/Utils/SearchHelper.php
@@ -126,18 +126,20 @@ class SearchHelper
             if (!$value) {
                 return [];
             }
-            $cookieValue = json_decode($value);
+            $cookieValue = json_decode($value, false);
             if (!$cookieValue) {
                 return [];
             }
             $attributions = [];
 
             foreach ($cookieValue as $abTest) {
-                if ($abTest->id && $abTest->activeVariation->id) {
-                    $attributions[] = new AbTestAttribution(
-                        $abTest->id,
-                        $abTest->activeVariation->id,
-                    );
+                $id = is_object($abTest) ? $abTest->id : $abTest['id'];
+                $variationId = is_object($abTest)
+                    ? $abTest->activeVariation->id
+                    : $abTest['activeVariation']['id'];
+
+                if ($id && $variationId) {
+                    $attributions[] = new AbTestAttribution($id, $variationId);
                 }
             }
 


### PR DESCRIPTION
 - Guard SearchHelper::parseAbTestCookie against cookies decoded as arrays by checking is_object and falling back to array access, preventing undefined property errors (src/Utils/
  SearchHelper.php:126).
  - Make the json_decode call explicit about returning objects (src/Utils/SearchHelper.php:129), so future refactors don’t flip it to associative arrays by accident.