### PR TITLE
NS-13181 adding a default image placeholder url to config

### DIFF
--- a/src/Model/Config/NostoConfigService.php
+++ b/src/Model/Config/NostoConfigService.php
@@ -108,6 +108,8 @@ class NostoConfigService
 
     public const SYNC_BATCH_SIZE = 'syncBatchSize';
 
+    public const FALLBACK_PRODUCT_IMAGE_URL = 'fallbackImageUrl';
+
     private array $configs = [];
 
     public function __construct(

--- a/src/Model/ConfigProvider.php
+++ b/src/Model/ConfigProvider.php
@@ -78,6 +78,23 @@ class ConfigProvider
         return is_string($domainId) ? $domainId : null;
     }
 
+    public function getFallbackImageUrl(?string $channelId = null, ?string $languageId = null): ?string
+    {
+        $value = $this->configService->get(
+            NostoConfigService::FALLBACK_PRODUCT_IMAGE_URL,
+            $channelId,
+            $languageId,
+        );
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+
     /**
      * @return string[]
      */

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -284,6 +284,15 @@ class ProductHelper
 
     protected function buildFallbackImage(SalesChannelContext $context, RequestContext $requestContext): string
     {
+        $configuredUrl = $this->configProvider->getFallbackImageUrl(
+            $context->getSalesChannelId(),
+            $context->getLanguageId(),
+        );
+
+        if ($configuredUrl) {
+            return $configuredUrl;
+        }
+
         $schemaAuthority = null;
 
         if ($domains = $context->getSalesChannel()->getDomains()) {

--- a/src/Resources/app/administration/src/module/nosto/components/nosto-integration-settings-general/index.js
+++ b/src/Resources/app/administration/src/module/nosto/components/nosto-integration-settings-general/index.js
@@ -81,6 +81,7 @@ Component.register('nosto-integration-settings-general', {
                 selectedCustomFields: [],
                 googleCategory: null,
                 isInitializeNostoAfterInteraction: null,
+                fallbackImageUrl: null,
             });
         },
 

--- a/src/Resources/app/administration/src/module/nosto/components/nosto-integration-settings-general/nosto-integration-settings-general.html.twig
+++ b/src/Resources/app/administration/src/module/nosto/components/nosto-integration-settings-general/nosto-integration-settings-general.html.twig
@@ -44,6 +44,30 @@
                     @update:value="onUpdateValue('domain', $event)"
                 />
             {% endblock %}
+            {% block nosto_integration_setting_fallback_image_url %}
+                <sw-inherit-wrapper
+                    :value="currentConfig['fallbackImageUrl']"
+                    :inheritedValue="configKey === null ? null : configs['null']['fallbackImageUrl']"
+                    :label="$tc('nosto.configuration.general.fallbackImage.label')"
+                    :help-text="$tc('nosto.configuration.general.fallbackImage.helpText')"
+                    @update:value="onUpdateValue('fallbackImageUrl', $event)"
+                >
+                    <template #content="props">
+                        <mt-text-field
+                            name="fallbackImageUrl"
+                            placeholder="https://example.com/placeholder.jpg"
+                            :placeholder="https://example.com/placeholder.jpg"
+                            :modelValue="props.currentValue"
+                            :is-inheritance-field="props.isInheritField"
+                            :is-inherited="props.isInherited"
+                            :disabled="props.isInherited"
+                            @update:modelValue="props.updateCurrentValue"
+                            @inheritance-restore="props.restoreInheritance"
+                            @inheritance-remove="props.removeInheritance"
+                        />
+                    </template>
+                </sw-inherit-wrapper>
+            {% endblock %}
         </mt-card>
 
         <mt-card

--- a/src/Resources/app/administration/src/module/nosto/components/nosto-integration-settings-general/nosto-integration-settings-general.html.twig
+++ b/src/Resources/app/administration/src/module/nosto/components/nosto-integration-settings-general/nosto-integration-settings-general.html.twig
@@ -56,10 +56,7 @@
                         <mt-text-field
                             name="fallbackImageUrl"
                             placeholder="https://example.com/placeholder.jpg"
-                            :placeholder="https://example.com/placeholder.jpg"
                             :modelValue="props.currentValue"
-                            :is-inheritance-field="props.isInheritField"
-                            :is-inherited="props.isInherited"
                             :disabled="props.isInherited"
                             @update:modelValue="props.updateCurrentValue"
                             @inheritance-restore="props.restoreInheritance"

--- a/src/Resources/app/administration/src/module/nosto/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/nosto/snippet/de-DE.json
@@ -55,6 +55,10 @@
                 "domain": {
                     "label": "Domäne für die Erzeugung der Produkturl, Kategorieurl und Platzhalterbildurl.",
                     "helpText": "Diese Domain wird für Multi-Domain-Verkaufskanäle verwendet, und die ausgewählte Domain wird als Uri für die Produkt-Url, Kategorieurl und Platzhalterbildurl verwendet."
+                },
+                "fallbackImage": {
+                    "label": "Fallback-Produktbild-URL",
+                    "helpText": "Optionale absolute URL, die an Nosto gesendet wird, wenn ein Produkt keine Medien hat. Leer lassen, um weiterhin den Standard-Shopware-Platzhalter unter bundles/storefront/assets/icon/default/placeholder.svg auf Ihrer Storefront-Domain zu verwenden."
                 }
             },
             "featuresFlags": {

--- a/src/Resources/app/administration/src/module/nosto/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/nosto/snippet/en-GB.json
@@ -55,6 +55,10 @@
                 "domain": {
                     "label": "Domain for generating product url, category url, and placeholder image url",
                     "helpText": "This domain is used for multi-domain sales channels, and the selected domain will be used as uri for product url, category url, and placeholder image url"
+                },
+                "fallbackImage": {
+                    "label": "Fallback product image URL",
+                    "helpText": "Optional absolute URL that will be sent to Nosto for products without media. Leave empty to keep using the default Shopware placeholder stored under bundles/storefront/assets/icon/default/placeholder.svg on your storefront domain."
                 }
             },
             "featuresFlags": {


### PR DESCRIPTION
 Summary

  - Added a configurable fallbackImageUrl setting (with EN/DE admin copy) so merchants can provide a custom placeholder for image-less products.
  - Wired the general settings card to expose the new inherited URL field and defaulted the state store key.
  - Product Helper now prefers the configured URL before falling back to the Shopware placeholder, so product and SKU builders automatically use merchant-provided images.