### PR TITLE
Split sync per sales channel-v5

### DIFF
--- a/src/Api/Controller/NostoCategoriesController.php
+++ b/src/Api/Controller/NostoCategoriesController.php
@@ -6,15 +6,14 @@ namespace Nosto\NostoIntegration\Api\Controller;
 
 use GuzzleHttp\Client;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [

--- a/src/Api/Controller/NostoCategoriesController.php
+++ b/src/Api/Controller/NostoCategoriesController.php
@@ -14,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [
@@ -43,7 +44,7 @@ class NostoCategoriesController extends AbstractController
     )]
     public function sync(Request $request, Context $context): JsonResponse
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addAssociation('children');
         $criteria->getAssociation('parent');
         $criteria->getAssociation('seoUrls');

--- a/src/Api/Controller/NostoMulticurrencyController.php
+++ b/src/Api/Controller/NostoMulticurrencyController.php
@@ -6,8 +6,8 @@ namespace Nosto\NostoIntegration\Api\Controller;
 
 use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [

--- a/src/Api/Controller/NostoMulticurrencyController.php
+++ b/src/Api/Controller/NostoMulticurrencyController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [
@@ -58,7 +59,7 @@ class NostoMulticurrencyController extends AbstractController
                 'error' => 'Too many product Ids provided limit is 50',
             ], Response::HTTP_BAD_REQUEST);
         }
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         if ($productIdentifier == ProductIdentifierOptions::PRODUCT_NUMBER) {
             $criteria->addFilter(new EqualsAnyFilter('productNumber', $productIdsArray));
         } else {

--- a/src/Api/Route/NostoSyncRoute.php
+++ b/src/Api/Route/NostoSyncRoute.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [
@@ -69,7 +70,8 @@ class NostoSyncRoute
 
     private function checkJobStatus(Context $context, string $type): void
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.nosto_sync_route.checkJobStatus');
         $criteria->addFilter(
             new AndFilter([
                 new EqualsFilter('type', $type),
@@ -88,7 +90,8 @@ class NostoSyncRoute
 
     private function checkCancelRunningFullProductSyncJobStatus(Context $context, string $type): void
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.nosto_sync_route.checkCancelRunningFullProductSyncJobStatus');
         $criteria->addFilter(
             new AndFilter([
                 new EqualsFilter('type', $type),

--- a/src/Api/Route/NostoSyncRoute.php
+++ b/src/Api/Route/NostoSyncRoute.php
@@ -7,20 +7,19 @@ namespace Nosto\NostoIntegration\Api\Route;
 use Exception;
 use Nosto\NostoIntegration\Async\FullCatalogSyncMessage;
 use Nosto\NostoIntegration\Service\NostoJobSyncService;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Scheduler\Entity\Job\JobEntity;
 use Nosto\Scheduler\Model\JobScheduler;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Api\Response\JsonApiResponse;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [
@@ -89,7 +88,9 @@ class NostoSyncRoute
 
     private function checkCancelRunningFullProductSyncJobStatus(Context $context, string $type): void
     {
-        $criteria = NostoCriteriaFactory::create('product_sync.nosto_sync_route.checkCancelRunningFullProductSyncJobStatus');
+        $criteria = NostoCriteriaFactory::create(
+            'product_sync.nosto_sync_route.checkCancelRunningFullProductSyncJobStatus',
+        );
         $criteria->addFilter(
             new AndFilter([
                 new EqualsFilter('type', $type),

--- a/src/Api/Route/NostoSyncRoute.php
+++ b/src/Api/Route/NostoSyncRoute.php
@@ -70,8 +70,7 @@ class NostoSyncRoute
 
     private function checkJobStatus(Context $context, string $type): void
     {
-        $criteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.nosto_sync_route.checkJobStatus');
+        $criteria = NostoCriteriaFactory::create('product_sync.nosto_sync_route.checkJobStatus');
         $criteria->addFilter(
             new AndFilter([
                 new EqualsFilter('type', $type),
@@ -90,8 +89,7 @@ class NostoSyncRoute
 
     private function checkCancelRunningFullProductSyncJobStatus(Context $context, string $type): void
     {
-        $criteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.nosto_sync_route.checkCancelRunningFullProductSyncJobStatus');
+        $criteria = NostoCriteriaFactory::create('product_sync.nosto_sync_route.checkCancelRunningFullProductSyncJobStatus');
         $criteria->addFilter(
             new AndFilter([
                 new EqualsFilter('type', $type),

--- a/src/Async/ProductSyncMessage.php
+++ b/src/Async/ProductSyncMessage.php
@@ -19,6 +19,8 @@ class ProductSyncMessage extends AbstractMessage implements ParentAwareMessageIn
         private readonly array $productIds,
         ?Context $context = null,
         ?string $name = null,
+        private readonly ?string $channelId = null,
+        private readonly ?string $languageId = null,
     ) {
         parent::__construct($jobId, $context, $name);
     }
@@ -39,5 +41,15 @@ class ProductSyncMessage extends AbstractMessage implements ParentAwareMessageIn
     public function getParentJobId(): string
     {
         return $this->parentJobId;
+    }
+
+    public function getChannelId(): ?string
+    {
+        return $this->channelId;
+    }
+
+    public function getLanguageId(): ?string
+    {
+        return $this->languageId;
     }
 }

--- a/src/Controller/Storefront/NostoMonitoringDebugController.php
+++ b/src/Controller/Storefront/NostoMonitoringDebugController.php
@@ -101,6 +101,8 @@ class NostoMonitoringDebugController extends AbstractNostoMonitoringController
                     ],
                     $salesChannelContext->getContext(),
                     'Product Debug',
+                    $salesChannelContext->getSalesChannelId(),
+                    $salesChannelContext->getLanguageId(),
                 ),
             );
 
@@ -308,6 +310,8 @@ class NostoMonitoringDebugController extends AbstractNostoMonitoringController
             ],
             $context->getContext(),
             'Product Debug',
+            $context->getSalesChannelId(),
+            $context->getLanguageId(),
         );
 
         $result = $this->productSyncHandler->execute($message);

--- a/src/Controller/Storefront/NostoMonitoringDebugController.php
+++ b/src/Controller/Storefront/NostoMonitoringDebugController.php
@@ -15,10 +15,10 @@ use Nosto\NostoIntegration\Model\Operation\OrderSyncHandler;
 use Nosto\NostoIntegration\Model\Operation\ProductSyncHandler;
 use Nosto\NostoIntegration\Service\NostoMonitoringAuthService;
 use Nosto\NostoIntegration\Service\NostoMonitoringProductDebug;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Scheduler\Model\Job\JobResult;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
@@ -27,7 +27,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(defaults: [
     '_routeScope' => ['storefront'],

--- a/src/Controller/Storefront/NostoMonitoringDebugController.php
+++ b/src/Controller/Storefront/NostoMonitoringDebugController.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(defaults: [
     '_routeScope' => ['storefront'],
@@ -72,7 +73,7 @@ class NostoMonitoringDebugController extends AbstractNostoMonitoringController
         }
 
         try {
-            $criteria = new Criteria([$productId]);
+            $criteria = NostoCriteriaFactory::createWithIds([$productId]);
             $criteria->addAssociations([
                 'categories',
                 'properties',
@@ -171,7 +172,7 @@ class NostoMonitoringDebugController extends AbstractNostoMonitoringController
         }
 
         try {
-            $criteria = new Criteria([$categoryId]);
+            $criteria = NostoCriteriaFactory::createWithIds([$categoryId]);
             $criteria->getAssociation('seoUrls');
 
             $category = $this->categoryRepository->search($criteria, $salesChannelContext->getContext())->first();
@@ -234,7 +235,7 @@ class NostoMonitoringDebugController extends AbstractNostoMonitoringController
         }
 
         try {
-            $criteria = new Criteria([$orderId]);
+            $criteria = NostoCriteriaFactory::createWithIds([$orderId]);
             $criteria->addAssociation('stateMachineState');
             $criteria->addAssociation('orderCustomer');
             $criteria->addAssociation('currency');

--- a/src/Controller/Storefront/NostoMonitoringOperationsController.php
+++ b/src/Controller/Storefront/NostoMonitoringOperationsController.php
@@ -6,16 +6,15 @@ namespace Nosto\NostoIntegration\Controller\Storefront;
 
 use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\NostoMonitoringHelper;
 use Nosto\NostoIntegration\Service\NostoMonitoringAuthService;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(defaults: [
     '_routeScope' => ['storefront'],

--- a/src/Controller/Storefront/NostoMonitoringOperationsController.php
+++ b/src/Controller/Storefront/NostoMonitoringOperationsController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(defaults: [
     '_routeScope' => ['storefront'],
@@ -48,11 +49,11 @@ class NostoMonitoringOperationsController extends AbstractNostoMonitoringControl
         $currentLanguageId = $request->get('languageId');
         $currentSalesChannelId = $request->get('salesChannelId');
 
-        $languageCriteria = new Criteria();
+        $languageCriteria = NostoCriteriaFactory::create();
         $languageCriteria->addAssociation('locale');
         $languages = $this->languageRepository->search($languageCriteria, $context)->getEntities();
 
-        $salesChannels = $this->salesChannelRepository->search(new Criteria(), $context)->getEntities();
+        $salesChannels = $this->salesChannelRepository->search(NostoCriteriaFactory::create(), $context)->getEntities();
         $nostoVersion = $this->nostoMonitoringHelper->getPluginVersion();
 
         return $this->renderStorefront(

--- a/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -10,6 +10,7 @@ use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Traits\SearchResultHelper;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\NostoIntegration\Utils\SearchHelper;
 use Nosto\Operation\Category\AnalyticsCategoryTrackingGraphql;
 use Psr\Log\LoggerInterface;
@@ -32,7 +33,6 @@ use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class ProductListingRoute extends AbstractProductListingRoute
 {

--- a/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -32,6 +32,7 @@ use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class ProductListingRoute extends AbstractProductListingRoute
 {
@@ -88,7 +89,7 @@ class ProductListingRoute extends AbstractProductListingRoute
                 ),
             );
             /** @var CategoryEntity $category */
-            $criteria = new Criteria([$categoryId]);
+            $criteria = NostoCriteriaFactory::createWithIds([$categoryId]);
             $criteria->addAssociation('seoUrls');
             $criteria->addAssociation('options.group');
 

--- a/src/Decorator/Storefront/Controller/CmsController.php
+++ b/src/Decorator/Storefront/Controller/CmsController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [
@@ -80,7 +81,7 @@ class CmsController extends StorefrontController
             return $this->decorated->filter($navigationId, $request, $salesChannelContext);
         }
 
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $this->searchService->doFilter($request, $criteria, $salesChannelContext);
 
         if (!$criteria->hasExtension('nostoAvailableFilters')) {

--- a/src/Decorator/Storefront/Controller/CmsController.php
+++ b/src/Decorator/Storefront/Controller/CmsController.php
@@ -7,8 +7,8 @@ namespace Nosto\NostoIntegration\Decorator\Storefront\Controller;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Search\Api\SearchService;
 use Nosto\NostoIntegration\Search\Request\Handler\FilterHandler;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\NostoIntegration\Utils\SearchHelper;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\CmsController as ShopwareCmsController;
 use Shopware\Storefront\Controller\StorefrontController;
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[Route(
     defaults: [

--- a/src/Decorator/Storefront/Controller/SearchController.php
+++ b/src/Decorator/Storefront/Controller/SearchController.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 /**
  * @see ShopwareSearchController
@@ -174,7 +175,7 @@ class SearchController extends StorefrontController
             return $this->decorated->filter($request, $salesChannelContext);
         }
 
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $this->searchService->doFilter($request, $criteria, $salesChannelContext);
 
         if (!$criteria->hasExtension('nostoAvailableFilters')) {

--- a/src/Decorator/Storefront/Controller/SearchController.php
+++ b/src/Decorator/Storefront/Controller/SearchController.php
@@ -8,8 +8,8 @@ use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Search\Api\SearchService;
 use Nosto\NostoIntegration\Search\Request\Handler\FilterHandler;
 use Nosto\NostoIntegration\Struct\Redirect;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\NostoIntegration\Utils\SearchHelper;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\SearchController as ShopwareSearchController;
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 /**
  * @see ShopwareSearchController

--- a/src/Model/Nosto/Account/Provider.php
+++ b/src/Model/Nosto/Account/Provider.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Throwable;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Provider
 {
@@ -46,7 +47,7 @@ class Provider
             return $this->accounts;
         }
 
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('type.name', 'Storefront'));
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addAssociation('languages');

--- a/src/Model/Nosto/Account/Provider.php
+++ b/src/Model/Nosto/Account/Provider.php
@@ -7,15 +7,14 @@ namespace Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Utils\Logger\ContextHelper;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Request\Api\Token;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Throwable;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Provider
 {

--- a/src/Model/Nosto/Entity/Customer/Builder.php
+++ b/src/Model/Nosto/Entity/Customer/Builder.php
@@ -6,14 +6,13 @@ namespace Nosto\NostoIntegration\Model\Nosto\Entity\Customer;
 
 use Nosto\Model\Customer;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Customer\Event\NostoCustomerBuiltEvent;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute as Newsletter;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Builder
 {

--- a/src/Model/Nosto/Entity/Customer/Builder.php
+++ b/src/Model/Nosto/Entity/Customer/Builder.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Builder
 {
@@ -37,7 +38,7 @@ class Builder
 
     private function hasMarketingPermission(CustomerEntity $customer, Context $context): bool
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('email', $customer->getEmail()));
         $subscriber = $this->newsletterRecipientRepository->search($criteria, $context)->first();
 

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -124,8 +124,7 @@ class ProductHelper
 
     public function getReviewsCount(SalesChannelProductEntity $product, SalesChannelContext $context): int
     {
-        $reviewCriteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($reviewCriteria, 'product_sync.productHelper.getReviewsCount');
+        $reviewCriteria = NostoCriteriaFactory::create('product_sync.productHelper.getReviewsCount');
         $reviewCriteria->addFilter(
             new MultiFilter(MultiFilter::CONNECTION_OR, [
                 new EqualsFilter('product.id', $product->getId()),
@@ -148,9 +147,9 @@ class ProductHelper
         return $shopwareProduct->get($productId) ?? null;
     }
 
-    private function getCommonCriteria(): Criteria
+    private function getCommonCriteria(?string $title = null): Criteria
     {
-        $criteria = NostoCriteriaFactory::create();
+        $criteria = NostoCriteriaFactory::create($title);
         $criteria->addAssociation('media');
         $criteria->addAssociation('cover');
         $criteria->addAssociation('options.group');
@@ -180,8 +179,7 @@ class ProductHelper
         $salesChannelId = $context->getSalesChannelId();
         $languageId = $context->getLanguageId();
 
-        $criteria = $this->getCommonCriteria();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.loadExistingParentProducts');
+        $criteria = $this->getCommonCriteria('product_sync.productHelper.loadExistingParentProducts');
         $criteria->addAssociation('children');
         $criteria->setLimit(100);
 
@@ -225,8 +223,7 @@ class ProductHelper
         $salesChannelId = $context->getSalesChannelId();
         $languageId = $context->getLanguageId();
 
-        $criteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.getProductsIterator');
+        $criteria = NostoCriteriaFactory::create('product_sync.productHelper.getProductsIterator');
         $criteria->setLimit(100);
         $criteria->addFilter(new EqualsAnyFilter('id', $productIds));
 
@@ -254,8 +251,7 @@ class ProductHelper
      */
     public function loadOrderNumberMapping(array $ids, Context $context): array
     {
-        $criteria = NostoCriteriaFactory::createWithIds($ids);
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.loadOrderNumberMapping');
+        $criteria = NostoCriteriaFactory::createWithIds($ids, 'product_sync.productHelper.loadOrderNumberMapping');
         $iterator = new RepositoryIterator($this->productRepository, $context, $criteria);
         $orderNumberMapping = [];
         while (($result = $iterator->fetch()) !== null) {
@@ -326,8 +322,7 @@ class ProductHelper
     ): SalesChannelProductCollection {
         $shouldLog = $this->shouldLogExtra($context);
         $startedAt = $shouldLog ? microtime(true) : null;
-        $criteria = $this->getCommonCriteria();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.getShopwareProducts');
+        $criteria = $this->getCommonCriteria('product_sync.productHelper.getShopwareProducts');
         if (!$isProductTagging) {
             $this->getCommonCriteriaChildren($criteria);
         }

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -36,6 +36,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class ProductHelper
 {
@@ -123,7 +124,8 @@ class ProductHelper
 
     public function getReviewsCount(SalesChannelProductEntity $product, SalesChannelContext $context): int
     {
-        $reviewCriteria = new Criteria();
+        $reviewCriteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($reviewCriteria, 'product_sync.productHelper.getReviewsCount');
         $reviewCriteria->addFilter(
             new MultiFilter(MultiFilter::CONNECTION_OR, [
                 new EqualsFilter('product.id', $product->getId()),
@@ -148,7 +150,7 @@ class ProductHelper
 
     private function getCommonCriteria(): Criteria
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addAssociation('media');
         $criteria->addAssociation('cover');
         $criteria->addAssociation('options.group');
@@ -179,6 +181,7 @@ class ProductHelper
         $languageId = $context->getLanguageId();
 
         $criteria = $this->getCommonCriteria();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.loadExistingParentProducts');
         $this->getCommonCriteriaChildren($criteria);
         $criteria->setLimit(100);
         $criteria->addAssociation('children.manufacturer');
@@ -225,7 +228,8 @@ class ProductHelper
         $salesChannelId = $context->getSalesChannelId();
         $languageId = $context->getLanguageId();
 
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.getProductsIterator');
         $criteria->setLimit(100);
         $criteria->addFilter(new EqualsAnyFilter('id', $productIds));
 
@@ -253,7 +257,8 @@ class ProductHelper
      */
     public function loadOrderNumberMapping(array $ids, Context $context): array
     {
-        $criteria = new Criteria($ids);
+        $criteria = NostoCriteriaFactory::createWithIds($ids);
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.loadOrderNumberMapping');
         $iterator = new RepositoryIterator($this->productRepository, $context, $criteria);
         $orderNumberMapping = [];
         while (($result = $iterator->fetch()) !== null) {
@@ -325,6 +330,7 @@ class ProductHelper
         $shouldLog = $this->shouldLogExtra($context);
         $startedAt = $shouldLog ? microtime(true) : null;
         $criteria = $this->getCommonCriteria();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.productHelper.getShopwareProducts');
         if (!$isProductTagging) {
             $this->getCommonCriteriaChildren($criteria);
         }

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -179,11 +179,8 @@ class ProductHelper
         $languageId = $context->getLanguageId();
 
         $criteria = $this->getCommonCriteria();
-        $this->getCommonCriteriaChildren($criteria);
+        $criteria->addAssociation('children');
         $criteria->setLimit(100);
-        $criteria->addAssociation('children.manufacturer');
-        $criteria->addAssociation('children.manufacturer.media');
-        $criteria->addAssociation('children.categoriesRo');
 
         if (!$this->configProvider->isEnabledSyncInactiveProducts($salesChannelId, $languageId)) {
             $criteria->addFilter(new EqualsFilter('active', true));

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -14,6 +14,7 @@ use Nosto\NostoIntegration\Search\Response\GraphQL\Filter\RangeSliderFilter;
 use Nosto\NostoIntegration\Search\Response\GraphQL\Filter\Values\FilterValue;
 use Nosto\NostoIntegration\Struct\FiltersExtension;
 use Nosto\NostoIntegration\Struct\IdToFieldMapping;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute;
@@ -36,7 +37,6 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class ProductHelper
 {

--- a/src/Model/Nosto/Entity/Order/Item/Builder.php
+++ b/src/Model/Nosto/Entity/Order/Item/Builder.php
@@ -10,15 +10,14 @@ use Nosto\NostoIntegration\Enums\ProductIdentifierOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\ProductProviderInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\NostoIntegration\Utils\ProductTaggingHelper;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Builder
 {
@@ -36,7 +35,9 @@ class Builder
         $criteria->addAssociation('children');
         /** @var ProductEntity|null $product */
         $product = $productRepository->search($criteria, $context->getContext())->first();
-        $criteria = NostoCriteriaFactory::createWithIds([$product->getParentId() != null ? $product->getParentId() : $product->getId()]);
+        $criteria = NostoCriteriaFactory::createWithIds([
+            $product->getParentId() != null ? $product->getParentId() : $product->getId(),
+        ]);
         $criteria->addAssociation('children');
         /** @var ProductEntity|null $parentProduct */
         $parentProduct = $productRepository->search($criteria, $context->getContext())->first();

--- a/src/Model/Nosto/Entity/Order/Item/Builder.php
+++ b/src/Model/Nosto/Entity/Order/Item/Builder.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Builder
 {
@@ -31,11 +32,11 @@ class Builder
         ProductHelper $productHelper,
         ProductProviderInterface $productProvider,
     ): NostoLineItem {
-        $criteria = new Criteria([$item->getProductId()]);
+        $criteria = NostoCriteriaFactory::createWithIds([$item->getProductId()]);
         $criteria->addAssociation('children');
         /** @var ProductEntity|null $product */
         $product = $productRepository->search($criteria, $context->getContext())->first();
-        $criteria = new Criteria([$product->getParentId() != null ? $product->getParentId() : $product->getId()]);
+        $criteria = NostoCriteriaFactory::createWithIds([$product->getParentId() != null ? $product->getParentId() : $product->getId()]);
         $criteria->addAssociation('children');
         /** @var ProductEntity|null $parentProduct */
         $parentProduct = $productRepository->search($criteria, $context->getContext())->first();

--- a/src/Model/Nosto/Entity/Product/Builder.php
+++ b/src/Model/Nosto/Entity/Product/Builder.php
@@ -136,8 +136,7 @@ class Builder
             $stockStatus = ProductInterface::IN_STOCK;
         }
 
-        $criteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.loadCategorySeoUrls');
+        $criteria = NostoCriteriaFactory::create('product_sync.builder.loadCategorySeoUrls');
         $criteria->addAssociation('seoUrls');
         $criteria->addFilter(new EqualsAnyFilter('id', array_values($product->getCategoriesRo()->getIds())));
         $productCategoriesRo = $this->categoryRepository->search($criteria, $context)->getEntities();
@@ -461,8 +460,7 @@ class Builder
         $missingIds = array_diff($tagIds, array_keys($cachedTags));
 
         if ($missingIds !== []) {
-            $criteria = NostoCriteriaFactory::create();
-            NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.loadTagsByIds');
+            $criteria = NostoCriteriaFactory::create('product_sync.builder.loadTagsByIds');
             $criteria->addFilter(new EqualsAnyFilter('id', array_values($missingIds)));
             $fetched = $this->tagRepository->search($criteria, $context->getContext())->getEntities();
 
@@ -569,8 +567,7 @@ class Builder
         $cacheKey = $this->buildCacheKey($context);
 
         if (!isset($this->dynamicGroupCategoriesCache[$cacheKey])) {
-            $criteria = NostoCriteriaFactory::create();
-            NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.dynamicGroupCategories');
+            $criteria = NostoCriteriaFactory::create('product_sync.builder.dynamicGroupCategories');
             $criteria->addFilter(
                 new EqualsFilter(
                     self::PRODUCT_ASSIGNMENT_TYPE,
@@ -622,8 +619,7 @@ class Builder
     {
         $categoriesPaths = array_filter(array_unique(explode('|', $allProductCategoryPaths)));
 
-        $criteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.categoriesTreeCollection');
+        $criteria = NostoCriteriaFactory::create('product_sync.builder.categoriesTreeCollection');
         $criteria->addFilter(
             new EqualsAnyFilter('id', $categoriesPaths),
         );
@@ -678,8 +674,7 @@ class Builder
             $salesChannelId = $context->getSalesChannelId();
             $languageId = $context->getLanguageId();
 
-            $criteria = NostoCriteriaFactory::create();
-            NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.childrenSku');
+            $criteria = NostoCriteriaFactory::create('product_sync.builder.childrenSku');
             $criteria->addAssociation('media');
             $criteria->addAssociation('cover');
             $criteria->addAssociation('options.group');

--- a/src/Model/Nosto/Entity/Product/Builder.php
+++ b/src/Model/Nosto/Entity/Product/Builder.php
@@ -40,6 +40,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Tag\TagCollection;
+use Shopware\Core\System\Tag\TagEntity;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class Builder
@@ -77,6 +78,16 @@ class Builder
      * @var array<string, bool>
      */
     private array $loggingCache = [];
+
+    /**
+     * @var array<string, CategoryCollection>
+     */
+    private array $dynamicGroupCategoriesCache = [];
+
+    /**
+     * @var array<string, array<string, TagEntity>>
+     */
+    private array $tagCache = [];
 
     /**
      * @throws NostoException
@@ -384,7 +395,7 @@ class Builder
             $tagIdsToLoad = [];
         }
 
-        $tags = $this->loadTagsByIds($tagIdsToLoad, $context->getContext());
+        $tags = $this->loadTagsByIds($tagIdsToLoad, $context);
 
         $nostoProduct->setTag1($this->getTagValues(
             $productEntity,
@@ -433,16 +444,38 @@ class Builder
         return $result;
     }
 
-    private function loadTagsByIds(array $tagIds, Context $context): TagCollection
+    private function loadTagsByIds(array $tagIds, SalesChannelContext $context): TagCollection
     {
         if ($tagIds === []) {
             return new TagCollection();
         }
 
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsAnyFilter('id', array_values($tagIds)));
+        $cacheKey = $this->buildCacheKey($context);
+        if (!isset($this->tagCache[$cacheKey])) {
+            $this->tagCache[$cacheKey] = [];
+        }
 
-        return $this->tagRepository->search($criteria, $context)->getEntities();
+        $cachedTags = &$this->tagCache[$cacheKey];
+        $missingIds = array_diff($tagIds, array_keys($cachedTags));
+
+        if ($missingIds !== []) {
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsAnyFilter('id', array_values($missingIds)));
+            $fetched = $this->tagRepository->search($criteria, $context->getContext())->getEntities();
+
+            foreach ($fetched as $tag) {
+                $cachedTags[$tag->getId()] = $tag;
+            }
+        }
+
+        $collection = new TagCollection();
+        foreach ($tagIds as $tagId) {
+            if (isset($cachedTags[$tagId])) {
+                $collection->add($cachedTags[$tagId]);
+            }
+        }
+
+        return $collection;
     }
 
     /**
@@ -530,15 +563,24 @@ class Builder
 
     private function getCategoriesWithDynamicProductGroups(SalesChannelContext $context): CategoryCollection
     {
-        $criteria = new Criteria();
-        $criteria->addFilter(
-            new EqualsFilter(
-                self::PRODUCT_ASSIGNMENT_TYPE,
-                CategoryDefinition::PRODUCT_ASSIGNMENT_TYPE_PRODUCT_STREAM,
-            ),
-        );
+        $cacheKey = $this->buildCacheKey($context);
 
-        return $this->categoryRepository->search($criteria, $context)->getEntities();
+        if (!isset($this->dynamicGroupCategoriesCache[$cacheKey])) {
+            $criteria = new Criteria();
+            $criteria->addFilter(
+                new EqualsFilter(
+                    self::PRODUCT_ASSIGNMENT_TYPE,
+                    CategoryDefinition::PRODUCT_ASSIGNMENT_TYPE_PRODUCT_STREAM,
+                ),
+            );
+
+            $this->dynamicGroupCategoriesCache[$cacheKey] = $this->categoryRepository->search(
+                $criteria,
+                $context,
+            )->getEntities();
+        }
+
+        return $this->dynamicGroupCategoriesCache[$cacheKey];
     }
 
     private function addCategoriesByDynamicGroupsAssigned(
@@ -595,6 +637,11 @@ class Builder
         }
 
         return $this->loggingCache[$cacheKey];
+    }
+
+    private function buildCacheKey(SalesChannelContext $context): string
+    {
+        return sprintf('%s-%s', $context->getSalesChannelId(), $context->getLanguageId());
     }
 
     private function logDuration(

--- a/src/Model/Nosto/Entity/Product/Builder.php
+++ b/src/Model/Nosto/Entity/Product/Builder.php
@@ -236,8 +236,8 @@ class Builder
         }
 
         if ($product->getCover()) {
-            $nostoProduct->setImageUrl($product->getCover()->getMedia()->getUrl());
-            $nostoProduct->setThumbUrl($product->getCover()->getMedia()->getUrl());
+            $nostoProduct->setImageUrl('https://placehold.co/800');
+            $nostoProduct->setThumbUrl('https://placehold.co/400');
         } else {
             $placeholderImageUrl = $this->productHelper->getFallbackImageUrl($context);
             $nostoProduct->setImageUrl($placeholderImageUrl);
@@ -679,6 +679,7 @@ class Builder
             $criteria->addAssociation('options.group');
             $criteria->addAssociation('properties.group');
             $criteria->addAssociation('manufacturer');
+            $criteria->addAssociation('manufacturer.media');
             $criteria->addAssociation('categoriesRo');
             $criteria->addAssociation('visibilities');
             $criteria->addFilter(new EqualsAnyFilter('id', $product->getChildren()->getIds()));

--- a/src/Model/Nosto/Entity/Product/Builder.php
+++ b/src/Model/Nosto/Entity/Product/Builder.php
@@ -236,8 +236,8 @@ class Builder
         }
 
         if ($product->getCover()) {
-            $nostoProduct->setImageUrl('https://placehold.co/800');
-            $nostoProduct->setThumbUrl('https://placehold.co/400');
+            $nostoProduct->setImageUrl($product->getCover()->getMedia()->getUrl());
+            $nostoProduct->setThumbUrl($product->getCover()->getMedia()->getUrl());
         } else {
             $placeholderImageUrl = $this->productHelper->getFallbackImageUrl($context);
             $nostoProduct->setImageUrl($placeholderImageUrl);

--- a/src/Model/Nosto/Entity/Product/Builder.php
+++ b/src/Model/Nosto/Entity/Product/Builder.php
@@ -17,6 +17,7 @@ use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\Category\TreeBuilder;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\CrossSelling\CrossSellingBuilder;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\Event\NostoProductBuiltEvent;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Types\Product\ProductInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Price\CashRounding;
@@ -31,9 +32,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
@@ -42,7 +41,6 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Tag\TagCollection;
 use Shopware\Core\System\Tag\TagEntity;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Builder
 {

--- a/src/Model/Nosto/Entity/Product/Builder.php
+++ b/src/Model/Nosto/Entity/Product/Builder.php
@@ -41,6 +41,7 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Tag\TagCollection;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Builder
 {
@@ -124,7 +125,8 @@ class Builder
             $stockStatus = ProductInterface::IN_STOCK;
         }
 
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.loadCategorySeoUrls');
         $criteria->addAssociation('seoUrls');
         $criteria->addFilter(new EqualsAnyFilter('id', array_values($product->getCategoriesRo()->getIds())));
         $productCategoriesRo = $this->categoryRepository->search($criteria, $context)->getEntities();
@@ -439,7 +441,8 @@ class Builder
             return new TagCollection();
         }
 
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.loadTagsByIds');
         $criteria->addFilter(new EqualsAnyFilter('id', array_values($tagIds)));
 
         return $this->tagRepository->search($criteria, $context)->getEntities();
@@ -530,7 +533,8 @@ class Builder
 
     private function getCategoriesWithDynamicProductGroups(SalesChannelContext $context): CategoryCollection
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.dynamicGroupCategories');
         $criteria->addFilter(
             new EqualsFilter(
                 self::PRODUCT_ASSIGNMENT_TYPE,
@@ -576,7 +580,8 @@ class Builder
     {
         $categoriesPaths = array_filter(array_unique(explode('|', $allProductCategoryPaths)));
 
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.categoriesTreeCollection');
         $criteria->addFilter(
             new EqualsAnyFilter('id', $categoriesPaths),
         );
@@ -626,7 +631,8 @@ class Builder
             $salesChannelId = $context->getSalesChannelId();
             $languageId = $context->getLanguageId();
 
-            $criteria = new Criteria();
+            $criteria = NostoCriteriaFactory::create();
+            NostoCriteriaFactory::setTitle($criteria, 'product_sync.builder.childrenSku');
             $criteria->addAssociation('media');
             $criteria->addAssociation('cover');
             $criteria->addAssociation('options.group');

--- a/src/Model/Nosto/Entity/Product/CrossSelling/CrossSellingBuilder.php
+++ b/src/Model/Nosto/Entity/Product/CrossSelling/CrossSellingBuilder.php
@@ -6,6 +6,7 @@ namespace Nosto\NostoIntegration\Model\Nosto\Entity\Product\CrossSelling;
 
 use Nosto\NostoIntegration\Enums\CrossSellingSyncOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingEntity;
@@ -21,7 +22,6 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class CrossSellingBuilder
 {

--- a/src/Model/Nosto/Entity/Product/CrossSelling/CrossSellingBuilder.php
+++ b/src/Model/Nosto/Entity/Product/CrossSelling/CrossSellingBuilder.php
@@ -21,6 +21,7 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class CrossSellingBuilder
 {
@@ -44,8 +45,8 @@ class CrossSellingBuilder
         foreach ($crossSellings as $crossSelling) {
             $result[$this->createKeyFromName($crossSelling->getTranslation('name'))] = [
                 'productIds' => $this->useProductStream($crossSelling)
-                    ? $this->loadByStream($crossSelling, $context, new Criteria())
-                    : $this->loadByIds($crossSelling, $context, new Criteria()),
+                    ? $this->loadByStream($crossSelling, $context, NostoCriteriaFactory::create())
+                    : $this->loadByIds($crossSelling, $context, NostoCriteriaFactory::create()),
                 'position' => $crossSelling->getPosition(),
                 'sortBy' => $crossSelling->getSortBy(),
                 'sortDirection' => $crossSelling->getSortDirection(),
@@ -65,7 +66,7 @@ class CrossSellingBuilder
         if ($syncConfig === CrossSellingSyncOptions::NO_SYNC) {
             return new ProductCrossSellingCollection();
         }
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria
             ->addAssociation('assignedProducts')
             ->addFilter(new EqualsFilter('product.id', $productId))

--- a/src/Model/Nosto/Entity/Product/SkuBuilder.php
+++ b/src/Model/Nosto/Entity/Product/SkuBuilder.php
@@ -76,6 +76,7 @@ class SkuBuilder
 
         if ($product->getCover() && $product->getCover()->getMedia()) {
             $nostoSku->setImageUrl($product->getCover()->getMedia()->getUrl());
+            $nostoSku->setImageUrl('https://placehold.co/800');
         } else {
             $placeholderImageUrl = $this->productHelper->getFallbackImageUrl($context);
             $nostoSku->setImageUrl($placeholderImageUrl);

--- a/src/Model/Nosto/Entity/Product/SkuBuilder.php
+++ b/src/Model/Nosto/Entity/Product/SkuBuilder.php
@@ -76,7 +76,6 @@ class SkuBuilder
 
         if ($product->getCover() && $product->getCover()->getMedia()) {
             $nostoSku->setImageUrl($product->getCover()->getMedia()->getUrl());
-            $nostoSku->setImageUrl('https://placehold.co/800');
         } else {
             $placeholderImageUrl = $this->productHelper->getFallbackImageUrl($context);
             $nostoSku->setImageUrl($placeholderImageUrl);

--- a/src/Model/Operation/CategorySyncHandler.php
+++ b/src/Model/Operation/CategorySyncHandler.php
@@ -82,8 +82,7 @@ class CategorySyncHandler implements JobHandlerInterface
 
     private function getCategories(Context $context, array $categoryIds): EntityCollection
     {
-        $criteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteria, 'product_sync.category_sync.getCategories');
+        $criteria = NostoCriteriaFactory::create('product_sync.category_sync.getCategories');
         $criteria->getAssociation('seoUrls');
         $criteria->addFilter(new EqualsAnyFilter('id', $categoryIds));
         $this->eventDispatcher->dispatch(new NostoCategoryCriteriaEvent($criteria, $context));

--- a/src/Model/Operation/CategorySyncHandler.php
+++ b/src/Model/Operation/CategorySyncHandler.php
@@ -10,12 +10,12 @@ use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Category\Builder as CategoryBuilder;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Category\Event\NostoCategoryCriteriaEvent;
 use Nosto\NostoIntegration\Model\Operation\Event\BeforeCategoryUpdateEvent;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Operation\Category\CategoryUpdate;
 use Nosto\Scheduler\Model\Job\Message\WarningMessage;
 use Nosto\Scheduler\Model\Job\{JobHandlerInterface, JobResult};
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\{EntityCollection, EntityRepository};
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,7 +24,6 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Throwable;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class CategorySyncHandler implements JobHandlerInterface
 {

--- a/src/Model/Operation/CategorySyncHandler.php
+++ b/src/Model/Operation/CategorySyncHandler.php
@@ -24,6 +24,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Throwable;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class CategorySyncHandler implements JobHandlerInterface
 {
@@ -81,7 +82,8 @@ class CategorySyncHandler implements JobHandlerInterface
 
     private function getCategories(Context $context, array $categoryIds): EntityCollection
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, 'product_sync.category_sync.getCategories');
         $criteria->getAssociation('seoUrls');
         $criteria->addFilter(new EqualsAnyFilter('id', $categoryIds));
         $this->eventDispatcher->dispatch(new NostoCategoryCriteriaEvent($criteria, $context));

--- a/src/Model/Operation/EntityChangelogSyncHandler.php
+++ b/src/Model/Operation/EntityChangelogSyncHandler.php
@@ -93,8 +93,7 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
         string $metricPrefix,
         callable $processCallback,
     ): void {
-        $criteria = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteria, $metricPrefix . '.delete');
+        $criteria = NostoCriteriaFactory::create($metricPrefix . '.delete');
         $criteria->addFilter(new EqualsFilter('entityType', $entityType));
         $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING));
         $criteria->setLimit(self::BATCH_SIZE);

--- a/src/Model/Operation/EntityChangelogSyncHandler.php
+++ b/src/Model/Operation/EntityChangelogSyncHandler.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandlerInterface
 {
@@ -90,7 +91,8 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
         string $metricPrefix,
         callable $processCallback,
     ): void {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteria, $metricPrefix . '.delete');
         $criteria->addFilter(new EqualsFilter('entityType', $entityType));
         $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING));
         $criteria->setLimit(self::BATCH_SIZE);

--- a/src/Model/Operation/EntityChangelogSyncHandler.php
+++ b/src/Model/Operation/EntityChangelogSyncHandler.php
@@ -12,6 +12,7 @@ use Nosto\NostoIntegration\Async\OrderSyncMessage;
 use Nosto\NostoIntegration\Async\ProductSyncMessage;
 use Nosto\NostoIntegration\Entity\Changelog\ChangelogEntity;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Model\Nosto\Account\Provider as AccountProvider;
 use Nosto\Scheduler\Model\Job\{GeneratingHandlerInterface, JobHandlerInterface, JobResult, Message\InfoMessage};
 use Nosto\Scheduler\Model\JobScheduler;
 use Psr\Log\LoggerInterface;
@@ -34,6 +35,7 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
         private readonly EntityRepository $entityChangelogRepository,
         private readonly JobScheduler $jobScheduler,
         private readonly ConfigProvider $configProvider,
+        private readonly AccountProvider $accountProvider,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -225,10 +227,25 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
             $result,
             $context
         ): void {
-            $jobMessage = new ProductSyncMessage(Uuid::randomHex(), $parentJobId, $productIds, $context);
-            $this->jobScheduler->schedule($jobMessage);
+            foreach ($this->accountProvider->all($context) as $account) {
+                $jobMessage = new ProductSyncMessage(
+                    Uuid::randomHex(),
+                    $parentJobId,
+                    $productIds,
+                    $context,
+                    null,
+                    $account->getChannelId(),
+                    $account->getLanguageId(),
+                );
+                $this->jobScheduler->schedule($jobMessage);
+            }
+
             $result->addMessage(new InfoMessage(
-                sprintf('Job with payload of %s updated products has been scheduled.', count($productIds)),
+                sprintf(
+                    'Job with payload of %s updated products has been scheduled for %s accounts.',
+                    count($productIds),
+                    count($this->accountProvider->all($context)),
+                ),
             ));
         });
     }

--- a/src/Model/Operation/EntityChangelogSyncHandler.php
+++ b/src/Model/Operation/EntityChangelogSyncHandler.php
@@ -13,6 +13,7 @@ use Nosto\NostoIntegration\Async\ProductSyncMessage;
 use Nosto\NostoIntegration\Entity\Changelog\ChangelogEntity;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Account\Provider as AccountProvider;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Scheduler\Model\Job\{GeneratingHandlerInterface, JobHandlerInterface, JobResult, Message\InfoMessage};
 use Nosto\Scheduler\Model\JobScheduler;
 use Psr\Log\LoggerInterface;
@@ -20,11 +21,9 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandlerInterface
 {

--- a/src/Model/Operation/FullCatalogSyncHandler.php
+++ b/src/Model/Operation/FullCatalogSyncHandler.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\{EqualsFilter, NotFilter};
 use Shopware\Core\Framework\Uuid\Uuid;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerInterface
 {
@@ -47,7 +48,8 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
         $shouldLogExtra = $this->shouldLogExtra();
         $syncStartedAt = $shouldLogExtra ? microtime(true) : null;
         $result = new JobResult();
-        $criteriaProduct = new Criteria();
+        $criteriaProduct = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteriaProduct, 'product_sync.full_catalog.products');
         $criteriaProduct->setLimit($size ? $size : self::BATCH_SIZE);
         $productRepositoryIterator = new RepositoryIterator(
             $this->productRepository,
@@ -100,7 +102,8 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
             );
         }
 
-        $criteriaCategory = new Criteria();
+        $criteriaCategory = NostoCriteriaFactory::create();
+        NostoCriteriaFactory::setTitle($criteriaCategory, 'product_sync.full_catalog.categories');
         $criteriaCategory->addFilter(new NotFilter(NotFilter::CONNECTION_AND, [
             new EqualsFilter('parentId', null),
         ]));

--- a/src/Model/Operation/FullCatalogSyncHandler.php
+++ b/src/Model/Operation/FullCatalogSyncHandler.php
@@ -8,6 +8,7 @@ use Nosto\NostoIntegration\Async\CategorySyncMessage;
 use Nosto\NostoIntegration\Async\FullCatalogSyncMessage;
 use Nosto\NostoIntegration\Async\ProductSyncMessage;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Model\Nosto\Account\Provider as AccountProvider;
 use Nosto\Scheduler\Model\Job\GeneratingHandlerInterface;
 use Nosto\Scheduler\Model\Job\JobHandlerInterface;
 use Nosto\Scheduler\Model\Job\JobResult;
@@ -33,6 +34,7 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
         private readonly EntityRepository $categoryRepository,
         private readonly JobScheduler $jobScheduler,
         private readonly ConfigProvider $configProvider,
+        private readonly AccountProvider $accountProvider,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -59,22 +61,35 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
         $productBatchCount = 0;
         $productCount = 0;
         $productsStartedAt = $shouldLogExtra ? microtime(true) : null;
+        $accounts = $this->accountProvider->all($context);
+
         while (($products = $productRepositoryIterator->fetch()) !== null) {
             ++$productBatchCount;
             $batchStartedAt = $shouldLogExtra ? microtime(true) : null;
             $ids = $this->getProductIdsForMessage($products->getEntities());
             $batchSize = count($ids);
             $productCount += $batchSize;
-            $this->jobScheduler->schedule(
-                new ProductSyncMessage(
-                    Uuid::randomHex(),
-                    $message->getJobId(),
-                    $ids,
-                    $message->getContext(),
-                ),
-            );
+            foreach ($accounts as $account) {
+                $this->jobScheduler->schedule(
+                    new ProductSyncMessage(
+                        Uuid::randomHex(),
+                        $message->getJobId(),
+                        $ids,
+                        $message->getContext(),
+                        null,
+                        $account->getChannelId(),
+                        $account->getLanguageId(),
+                    ),
+                );
+            }
             $result->addMessage(
-                new InfoMessage('Job with payload of: ' . count($ids) . ' products has been scheduled.'),
+                new InfoMessage(
+                    sprintf(
+                        'Job with payload of: %s products has been scheduled for %s accounts.',
+                        count($ids),
+                        count($accounts),
+                    ),
+                ),
             );
             if ($shouldLogExtra && $batchStartedAt !== null) {
                 $this->logDuration(

--- a/src/Model/Operation/FullCatalogSyncHandler.php
+++ b/src/Model/Operation/FullCatalogSyncHandler.php
@@ -50,8 +50,7 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
         $shouldLogExtra = $this->shouldLogExtra();
         $syncStartedAt = $shouldLogExtra ? microtime(true) : null;
         $result = new JobResult();
-        $criteriaProduct = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteriaProduct, 'product_sync.full_catalog.products');
+        $criteriaProduct = NostoCriteriaFactory::create('product_sync.full_catalog.products');
         $criteriaProduct->setLimit($size ? $size : self::BATCH_SIZE);
         $productRepositoryIterator = new RepositoryIterator(
             $this->productRepository,
@@ -117,8 +116,7 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
             );
         }
 
-        $criteriaCategory = NostoCriteriaFactory::create();
-        NostoCriteriaFactory::setTitle($criteriaCategory, 'product_sync.full_catalog.categories');
+        $criteriaCategory = NostoCriteriaFactory::create('product_sync.full_catalog.categories');
         $criteriaCategory->addFilter(new NotFilter(NotFilter::CONNECTION_AND, [
             new EqualsFilter('parentId', null),
         ]));

--- a/src/Model/Operation/FullCatalogSyncHandler.php
+++ b/src/Model/Operation/FullCatalogSyncHandler.php
@@ -9,6 +9,7 @@ use Nosto\NostoIntegration\Async\FullCatalogSyncMessage;
 use Nosto\NostoIntegration\Async\ProductSyncMessage;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Account\Provider as AccountProvider;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Scheduler\Model\Job\GeneratingHandlerInterface;
 use Nosto\Scheduler\Model\Job\JobHandlerInterface;
 use Nosto\Scheduler\Model\Job\JobResult;
@@ -19,10 +20,8 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\{EqualsFilter, NotFilter};
 use Shopware\Core\Framework\Uuid\Uuid;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerInterface
 {

--- a/src/Model/Operation/MarketingPermissionSyncHandler.php
+++ b/src/Model/Operation/MarketingPermissionSyncHandler.php
@@ -7,17 +7,16 @@ namespace Nosto\NostoIntegration\Model\Operation;
 use Nosto\NostoIntegration\Async\MarketingPermissionSyncMessage;
 use Nosto\NostoIntegration\Model\Nosto\Account;
 use Nosto\NostoIntegration\Model\Operation\Event\BeforeMarketingOperationEvent;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Operation\MarketingPermission;
 use Nosto\Scheduler\Model\Job\{JobHandlerInterface, JobResult};
 use Nosto\Types\Signup\AccountInterface;
 use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\{EntityCollection, EntityRepository};
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Throwable;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class MarketingPermissionSyncHandler implements JobHandlerInterface
 {

--- a/src/Model/Operation/MarketingPermissionSyncHandler.php
+++ b/src/Model/Operation/MarketingPermissionSyncHandler.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\{EntityCollection, EntityRepository};
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Throwable;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class MarketingPermissionSyncHandler implements JobHandlerInterface
 {
@@ -84,7 +85,7 @@ class MarketingPermissionSyncHandler implements JobHandlerInterface
 
     private function getSubscribers(Context $context, array $subscriberIds): EntityCollection
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsAnyFilter('id', $subscriberIds));
 
         return $this->newsletterRecipientRepository->search($criteria, $context)->getEntities();

--- a/src/Model/Operation/OrderSyncHandler.php
+++ b/src/Model/Operation/OrderSyncHandler.php
@@ -24,6 +24,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Throwable;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class OrderSyncHandler implements JobHandlerInterface
 {
@@ -98,7 +99,7 @@ class OrderSyncHandler implements JobHandlerInterface
                 $ids[] = $entityId;
             }
         }
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addAssociation('stateMachineState');
         $criteria->addAssociation('orderCustomer');
         $criteria->addAssociation('currency');

--- a/src/Model/Operation/OrderSyncHandler.php
+++ b/src/Model/Operation/OrderSyncHandler.php
@@ -10,12 +10,12 @@ use Nosto\NostoIntegration\Model\Nosto\Entity\Order\Builder as OrderBuilder;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Order\Event\NostoOrderCriteriaEvent;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Order\Status\Builder as OrderStatusBuilder;
 use Nosto\NostoIntegration\Model\Operation\Event\BeforeOrderCreatedEvent;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Operation\AbstractGraphQLOperation;
 use Nosto\Operation\Order\{OrderCreate, OrderStatus};
 use Nosto\Scheduler\Model\Job\{JobHandlerInterface, JobResult};
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\{EntityCollection, EntityRepository, Search\Filter\EqualsFilter};
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,7 +24,6 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Throwable;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class OrderSyncHandler implements JobHandlerInterface
 {

--- a/src/Model/Operation/ProductSyncHandler.php
+++ b/src/Model/Operation/ProductSyncHandler.php
@@ -139,8 +139,15 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         $parentProductIterator = $this->productHelper->loadExistingParentProducts($existentProducts, $context);
         $parentFetchStartedAt = $shouldLogExtra ? microtime(true) : null;
         $processedParentCount = 0;
+        $parentBatchIndex = 0;
 
-        while (($products = $parentProductIterator->fetch()) !== null) {
+        while (true) {
+            $batchStartedAt = $shouldLogExtra ? microtime(true) : null;
+            $products = $parentProductIterator->fetch();
+            if ($products === null) {
+                break;
+            }
+            ++$parentBatchIndex;
             foreach ($products->getEntities() as $product) {
                 try {
                     $productCollection = new ProductCollection([$product]);
@@ -164,6 +171,17 @@ class ProductSyncHandler implements Job\JobHandlerInterface
                     $wrappedException = new \RuntimeException($message, 0, $e);
                     $result->addError($wrappedException);
                 }
+            }
+            if ($shouldLogExtra && $batchStartedAt !== null) {
+                $this->logDuration(
+                    $context,
+                    'product_sync.loadExistingParentProducts.fetch.batch',
+                    $batchStartedAt,
+                    [
+                        'batch_index' => $parentBatchIndex,
+                        'batch_size' => $products->getEntities()->count(),
+                    ],
+                );
             }
         }
 

--- a/src/Model/Operation/ProductSyncHandler.php
+++ b/src/Model/Operation/ProductSyncHandler.php
@@ -64,7 +64,9 @@ class ProductSyncHandler implements Job\JobHandlerInterface
     {
         $operationResult = new Job\JobResult();
 
-        foreach ($this->accountProvider->all($message->getContext()) as $account) {
+        $accounts = $this->resolveAccounts($message);
+
+        foreach ($accounts as $account) {
             $channelContext = $this->channelContextFactory->create(
                 Uuid::randomHex(),
                 $account->getChannelId(),
@@ -82,6 +84,23 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         }
 
         return $operationResult;
+    }
+
+    /**
+     * @return Account[]
+     */
+    private function resolveAccounts(ProductSyncMessage $message): array
+    {
+        $context = $message->getContext();
+        $channelId = $message->getChannelId();
+        $languageId = $message->getLanguageId();
+
+        if ($channelId && $languageId) {
+            $account = $this->accountProvider->get($context, $channelId, $languageId);
+            return $account ? [$account] : [];
+        }
+
+        return $this->accountProvider->all($context);
     }
 
     /**
@@ -141,30 +160,9 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         $processedParentCount = 0;
 
         while (($products = $parentProductIterator->fetch()) !== null) {
-            foreach ($products->getEntities() as $product) {
-                try {
-                    $productCollection = new ProductCollection([$product]);
-
-                    $this->doUpsertOperation($account, $context, $productCollection, $result, $ids);
-                    ++$processedParentCount;
-                } catch (\Throwable $e) {
-                    $productId = $product->getId();
-                    $productNumber = method_exists(
-                        $product,
-                        'getProductNumber',
-                    ) ? $product->getProductNumber() : 'unknown';
-
-                    $message = sprintf(
-                        'Error while processing product ID: %s (Product Number: %s): %s',
-                        $productId,
-                        $productNumber,
-                        $e->getMessage(),
-                    );
-
-                    $wrappedException = new \RuntimeException($message, 0, $e);
-                    $result->addError($wrappedException);
-                }
-            }
+            $productCollection = $products->getEntities();
+            $this->doUpsertOperation($account, $context, $productCollection, $result, $ids);
+            $processedParentCount += $productCollection->count();
         }
 
         if ($shouldLogExtra && $parentFetchStartedAt !== null) {
@@ -240,114 +238,135 @@ class ProductSyncHandler implements Job\JobHandlerInterface
             $this->productHelper,
         );
 
+        $hasProducts = false;
+
         /** @var ProductEntity $product */
         foreach ($productCollection as $product) {
-            // TODO: up to 2MB payload!
-            $nostoProducts = [];
+            try {
+                // TODO: up to 2MB payload!
+                $nostoProducts = [];
 
-            $findProductIdStartedAt = $shouldLogExtra ? microtime(true) : null;
-            $handledProducts = $productTaggingHelper->findProductId(
-                $context,
-                $product,
-                null,
-                true,
-                true,
-            );
-
-            if ($shouldLogExtra && $findProductIdStartedAt !== null) {
-                $this->logDuration(
+                $findProductIdStartedAt = $shouldLogExtra ? microtime(true) : null;
+                $handledProducts = $productTaggingHelper->findProductId(
                     $context,
-                    'product_sync.productTaggingHelper.findProductId',
-                    $findProductIdStartedAt,
-                    [
-                        'product_id' => $product->getId(),
-                        'handled_count' => $handledProducts->count(),
-                    ],
+                    $product,
+                    null,
+                    true,
+                    true,
                 );
-            }
 
-            if (!$handledProducts->count()) {
-                $this->deleteVariantProducts($product, $context, $account, $ids);
-                $this->doDeleteOperation(
-                    $account,
-                    $context,
-                    [$product->getId(), $product->getParentId()],
-                    $ids,
-                );
-            }
-
-            $shopwareProductsFetchStartedAt = $shouldLogExtra ? microtime(true) : null;
-            $shopwareProducts = $handledProducts->count()
-                ? $this->productHelper->getShopwareProducts($handledProducts->getIds(), $context)
-                : new ProductCollection();
-            if ($shouldLogExtra && $shopwareProductsFetchStartedAt !== null) {
-                $this->logDuration(
-                    $context,
-                    'product_sync.getShopwareProducts',
-                    $shopwareProductsFetchStartedAt,
-                    [
-                        'handled_count' => $handledProducts->count(),
-                        'loaded_count' => $shopwareProducts->count(),
-                    ],
-                );
-            }
-
-            foreach ($handledProducts as $handledProduct) {
-                $shopwareProduct = $shopwareProducts->get($handledProduct->getId());
-                $productStartedAt = $shouldLogExtra ? microtime(true) : null;
-                $handledResult = 'skipped';
-
-                if ($shopwareProduct) {
-                    $shopwareProduct->setChildren($handledProduct->getChildren());
-                    $nostoProduct = $this->handleProduct(
-                        $shopwareProduct,
-                        $context,
-                        $account,
-                        $hideProductsAfterClearance,
-                        $ids,
-                    );
-
-                    if ($nostoProduct) {
-                        $nostoProducts[] = $nostoProduct;
-                        $handledResult = 'prepared';
-                    }
-                } else {
-                    $this->deleteVariantProducts($handledProduct, $context, $account, $ids);
-                    $this->doDeleteOperation(
-                        $account,
-                        $context,
-                        [$handledProduct->getId(), $handledProduct->getParentId()],
-                        $ids,
-                    );
-                    $handledResult = 'deleted';
-                }
-
-                if ($shouldLogExtra && $productStartedAt !== null) {
+                if ($shouldLogExtra && $findProductIdStartedAt !== null) {
                     $this->logDuration(
                         $context,
-                        'product_sync.product_handle',
-                        $productStartedAt,
+                        'product_sync.productTaggingHelper.findProductId',
+                        $findProductIdStartedAt,
                         [
-                            'product_id' => $handledProduct->getId(),
-                            'result' => $handledResult,
+                            'product_id' => $product->getId(),
+                            'handled_count' => $handledProducts->count(),
                         ],
                     );
                 }
-            }
 
-            foreach ($nostoProducts as $preparedProductForSync) {
-                $invalidMessage = $this->validateProduct(
-                    $preparedProductForSync->getProductId(),
-                    $preparedProductForSync,
-                );
-
-                if ($invalidMessage) {
-                    $result->addMessage($invalidMessage);
-                    continue;
+                if (!$handledProducts->count()) {
+                    $this->deleteVariantProducts($product, $context, $account, $ids);
+                    $this->doDeleteOperation(
+                        $account,
+                        $context,
+                        [$product->getId(), $product->getParentId()],
+                        $ids,
+                    );
                 }
 
-                $operation->addProduct($preparedProductForSync);
+                $shopwareProductsFetchStartedAt = $shouldLogExtra ? microtime(true) : null;
+                $shopwareProducts = $handledProducts->count()
+                    ? $this->productHelper->getShopwareProducts($handledProducts->getIds(), $context)
+                    : new ProductCollection();
+                if ($shouldLogExtra && $shopwareProductsFetchStartedAt !== null) {
+                    $this->logDuration(
+                        $context,
+                        'product_sync.getShopwareProducts',
+                        $shopwareProductsFetchStartedAt,
+                        [
+                            'handled_count' => $handledProducts->count(),
+                            'loaded_count' => $shopwareProducts->count(),
+                        ],
+                    );
+                }
+
+                foreach ($handledProducts as $handledProduct) {
+                    $shopwareProduct = $shopwareProducts->get($handledProduct->getId());
+                    $productStartedAt = $shouldLogExtra ? microtime(true) : null;
+                    $handledResult = 'skipped';
+
+                    if ($shopwareProduct) {
+                        $shopwareProduct->setChildren($handledProduct->getChildren());
+                        $nostoProduct = $this->handleProduct(
+                            $shopwareProduct,
+                            $context,
+                            $account,
+                            $hideProductsAfterClearance,
+                            $ids,
+                        );
+
+                        if ($nostoProduct) {
+                            $nostoProducts[] = $nostoProduct;
+                            $handledResult = 'prepared';
+                        }
+                    } else {
+                        $this->deleteVariantProducts($handledProduct, $context, $account, $ids);
+                        $this->doDeleteOperation(
+                            $account,
+                            $context,
+                            [$handledProduct->getId(), $handledProduct->getParentId()],
+                            $ids,
+                        );
+                        $handledResult = 'deleted';
+                    }
+
+                    if ($shouldLogExtra && $productStartedAt !== null) {
+                        $this->logDuration(
+                            $context,
+                            'product_sync.product_handle',
+                            $productStartedAt,
+                            [
+                                'product_id' => $handledProduct->getId(),
+                                'result' => $handledResult,
+                            ],
+                        );
+                    }
+                }
+
+                foreach ($nostoProducts as $preparedProductForSync) {
+                    $invalidMessage = $this->validateProduct(
+                        $preparedProductForSync->getProductId(),
+                        $preparedProductForSync,
+                    );
+
+                    if ($invalidMessage) {
+                        $result->addMessage($invalidMessage);
+                        continue;
+                    }
+
+                    $operation->addProduct($preparedProductForSync);
+                    $hasProducts = true;
+                }
+            } catch (\Throwable $e) {
+                $productId = $product->getId();
+                $productNumber = method_exists($product, 'getProductNumber') ? $product->getProductNumber() : 'unknown';
+                $message = sprintf(
+                    'Error while processing product ID: %s (Product Number: %s): %s',
+                    $productId,
+                    $productNumber,
+                    $e->getMessage(),
+                );
+
+                $wrappedException = new \RuntimeException($message, 0, $e);
+                $result->addError($wrappedException);
             }
+        }
+
+        if (!$hasProducts) {
+            return;
         }
 
         $dispatchStartedAt = $shouldLogExtra ? microtime(true) : null;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -333,6 +333,7 @@
             <argument key="$productProvider" type="service"
                       id="Nosto\NostoIntegration\Model\Nosto\Entity\Product\CachedProvider"/>
             <argument key="$ruleLoader" type="service" id="Shopware\Core\Checkout\Cart\RuleLoader"/>
+            <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
         </service>
 
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -18,6 +18,7 @@
 
             <argument key="$productRepository" type="service" id="product.repository"/>
             <argument key="$categoryRepository" type="service" id="category.repository"/>
+            <argument key="$accountProvider" type="service" id="Nosto\NostoIntegration\Model\Nosto\Account\Provider"/>
             <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
         </service>
 
@@ -54,6 +55,7 @@
 
             <argument key="$entityChangelogRepository" type="service"
                       id="nosto_integration_entity_changelog.repository"/>
+            <argument key="$accountProvider" type="service" id="Nosto\NostoIntegration\Model\Nosto\Account\Provider"/>
             <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
         </service>
 

--- a/src/Search/Request/Handler/NavigationRequestHandler.php
+++ b/src/Search/Request/Handler/NavigationRequestHandler.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NavigationRequestHandler extends AbstractRequestHandler
 {
@@ -69,7 +70,7 @@ class NavigationRequestHandler extends AbstractRequestHandler
 
     private function fetchCategoryPath(string $categoryId, SalesChannelContext $context): ?string
     {
-        $criteria = new Criteria([$categoryId]);
+        $criteria = NostoCriteriaFactory::createWithIds([$categoryId]);
         $criteria->addAssociation('seoUrls');
 
         /** @var ?CategoryEntity $category */

--- a/src/Search/Request/Handler/NavigationRequestHandler.php
+++ b/src/Search/Request/Handler/NavigationRequestHandler.php
@@ -9,13 +9,13 @@ use Nosto\NostoIntegration\Enums\CategoryNamingOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\Builder;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\Category\TreeBuilder;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Result\Graphql\Search\SearchResult;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NavigationRequestHandler extends AbstractRequestHandler
 {

--- a/src/Search/Request/Handler/SortingHandlerService.php
+++ b/src/Search/Request/Handler/SortingHandlerService.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class SortingHandlerService
 {
@@ -76,14 +77,14 @@ class SortingHandlerService
             return $id;
         }
 
-        $criteria = new Criteria([$id]);
+        $criteria = NostoCriteriaFactory::createWithIds([$id]);
 
         return $this->sortingRepository->search($criteria, $context->getContext())->first()?->get('key');
     }
 
     public function getNostoSortingPriority(SalesChannelContext $context): ?int
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('key', RecommendationSortingHandler::MERCHANDISING_SORTING_KEY));
         $criteria->setLimit(1);
         $sorting = $this->sortingRepository->search($criteria, $context->getContext())->first();

--- a/src/Search/Request/Handler/SortingHandlerService.php
+++ b/src/Search/Request/Handler/SortingHandlerService.php
@@ -15,6 +15,7 @@ use Nosto\NostoIntegration\Search\Request\Handler\SortHandlers\ScoreSortingHandl
 use Nosto\NostoIntegration\Search\Request\Handler\SortHandlers\SortingHandlerInterface;
 use Nosto\NostoIntegration\Search\Request\Handler\SortHandlers\StockSortingHandler;
 use Nosto\NostoIntegration\Search\Request\Handler\SortHandlers\TopSellerSortingHandler;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Operation\Search\SearchOperation;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -22,7 +23,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class SortingHandlerService
 {

--- a/src/Service/NostoJobSyncService.php
+++ b/src/Service/NostoJobSyncService.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NostoJobSyncService
 {
@@ -49,7 +50,7 @@ class NostoJobSyncService
     private function getAllRunningFullProductSyncJobIds(Context $context, string $handlerCode): array
     {
         // 1. Find parent jobs: parent_id IS NULL AND status IN ('running', 'pending')
-        $parentCriteria = new Criteria();
+        $parentCriteria = NostoCriteriaFactory::create();
         $parentCriteria->addFilter(
             new AndFilter([
                 new EqualsFilter('type', $handlerCode),
@@ -63,7 +64,7 @@ class NostoJobSyncService
         // 2. Find child jobs: parent_id IN (parentJobIds)
         $childJobIds = [];
         if (!empty($parentJobIds)) {
-            $childCriteria = new Criteria();
+            $childCriteria = NostoCriteriaFactory::create();
             $childCriteria->addFilter(
                 new AndFilter([
                     new EqualsFilter('type', $handlerCode),

--- a/src/Service/NostoJobSyncService.php
+++ b/src/Service/NostoJobSyncService.php
@@ -6,14 +6,13 @@ namespace Nosto\NostoIntegration\Service;
 
 use Doctrine\DBAL\Connection;
 use Exception;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Scheduler\Entity\Job\JobEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NostoJobSyncService
 {

--- a/src/Service/NostoMonitoringAuthService.php
+++ b/src/Service/NostoMonitoringAuthService.php
@@ -7,15 +7,14 @@ namespace Nosto\NostoIntegration\Service;
 use Nosto\Model\Signup\Account as NostoSignupAccount;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\MockOperation\MockGraphQLOperation;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Request\Api\Token as NostoToken;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NostoMonitoringAuthService
 {

--- a/src/Service/NostoMonitoringAuthService.php
+++ b/src/Service/NostoMonitoringAuthService.php
@@ -15,6 +15,7 @@ use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NostoMonitoringAuthService
 {
@@ -73,7 +74,7 @@ class NostoMonitoringAuthService
 
     private function validateFromApp(string $accessKey, Context $context): bool
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
 
         /** @var SalesChannelCollection $salesChannels */
         $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();

--- a/src/Service/NostoMonitoringProductDebug.php
+++ b/src/Service/NostoMonitoringProductDebug.php
@@ -13,6 +13,7 @@ use Nosto\NostoIntegration\Model\Operation\ProductSyncHandler;
 use Nosto\NostoIntegration\Utils\ProductTaggingHelper;
 use Nosto\Request\Http\Exception\AbstractHttpException;
 use Nosto\Scheduler\Model\Job;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
@@ -36,6 +37,7 @@ class NostoMonitoringProductDebug extends ProductSyncHandler
         private readonly ProductHelper $productHelper,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly SystemConfigService $systemConfigService,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct(
             $this->channelContextFactory,
@@ -46,6 +48,7 @@ class NostoMonitoringProductDebug extends ProductSyncHandler
             $this->productHelper,
             $this->eventDispatcher,
             $this->systemConfigService,
+            $this->logger,
         );
     }
 

--- a/src/Service/ScheduledTask/OldJobCleanupScheduledTaskHandler.php
+++ b/src/Service/ScheduledTask/OldJobCleanupScheduledTaskHandler.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Throwable;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[AsMessageHandler(handles: OldJobCleanupScheduledTask::class)]
 class OldJobCleanupScheduledTaskHandler extends ScheduledTaskHandler
@@ -43,7 +44,7 @@ class OldJobCleanupScheduledTaskHandler extends ScheduledTaskHandler
 
                 // Here we have context-less process
                 $context = new Context(new SystemSource());
-                $criteria = new Criteria();
+                $criteria = NostoCriteriaFactory::create();
                 $criteria->addFilter(
                     new AndFilter([
                         new RangeFilter(

--- a/src/Service/ScheduledTask/OldJobCleanupScheduledTaskHandler.php
+++ b/src/Service/ScheduledTask/OldJobCleanupScheduledTaskHandler.php
@@ -6,12 +6,12 @@ namespace Nosto\NostoIntegration\Service\ScheduledTask;
 
 use DateTime;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -19,7 +19,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Throwable;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 #[AsMessageHandler(handles: OldJobCleanupScheduledTask::class)]
 class OldJobCleanupScheduledTaskHandler extends ScheduledTaskHandler

--- a/src/Storefront/Checkout/Cart/RestoreUrlService/RestoreUrlService.php
+++ b/src/Storefront/Checkout/Cart/RestoreUrlService/RestoreUrlService.php
@@ -17,6 +17,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class RestoreUrlService
 {
@@ -42,7 +43,7 @@ class RestoreUrlService
 
     protected function fetchFromDb(string $token, Context $context): ?CheckoutMappingEntity
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(
             new EqualsFilter('reference', $token),
             new EqualsFilter('mappingTable', CheckoutMappingDefinition::CART_TABLE),

--- a/src/Storefront/Checkout/Cart/RestoreUrlService/RestoreUrlService.php
+++ b/src/Storefront/Checkout/Cart/RestoreUrlService/RestoreUrlService.php
@@ -7,9 +7,9 @@ namespace Nosto\NostoIntegration\Storefront\Checkout\Cart\RestoreUrlService;
 use Nosto\NostoIntegration\Entity\CheckoutMapping\CheckoutMappingDefinition;
 use Nosto\NostoIntegration\Entity\CheckoutMapping\CheckoutMappingEntity;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -17,7 +17,6 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class RestoreUrlService
 {

--- a/src/Storefront/Checkout/Cart/RestorerService/RestorerService.php
+++ b/src/Storefront/Checkout/Cart/RestorerService/RestorerService.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Throwable;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class RestorerService
 {
@@ -52,7 +53,7 @@ class RestorerService
 
     protected function loadMapping(string $mappingId, Context $context): ?CheckoutMappingEntity
     {
-        return $this->mappingRepository->search(new Criteria([$mappingId]), $context)->first();
+        return $this->mappingRepository->search(NostoCriteriaFactory::createWithIds([$mappingId]), $context)->first();
     }
 
     protected function restoreCart(string $token, SalesChannelContext $context): void
@@ -88,7 +89,7 @@ class RestorerService
 
     private function getOrderById(string $orderId, Context $context): ?OrderEntity
     {
-        $criteria = (new Criteria([$orderId]))
+        $criteria = (NostoCriteriaFactory::createWithIds([$orderId]))
             ->addAssociation('lineItems')
             ->addAssociation('currency')
             ->addAssociation('deliveries')

--- a/src/Storefront/Checkout/Cart/RestorerService/RestorerService.php
+++ b/src/Storefront/Checkout/Cart/RestorerService/RestorerService.php
@@ -7,6 +7,7 @@ namespace Nosto\NostoIntegration\Storefront\Checkout\Cart\RestorerService;
 use Nosto\NostoIntegration\Entity\CheckoutMapping\CheckoutMappingDefinition;
 use Nosto\NostoIntegration\Entity\CheckoutMapping\CheckoutMappingEntity;
 use Nosto\NostoIntegration\Utils\Logger\ContextHelper;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
@@ -15,10 +16,8 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Throwable;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class RestorerService
 {

--- a/src/Traits/SearchResultHelper.php
+++ b/src/Traits/SearchResultHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\Traits;
 
 use Nosto\NostoIntegration\Struct\Pagination;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
@@ -15,7 +16,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 trait SearchResultHelper
 {

--- a/src/Traits/SearchResultHelper.php
+++ b/src/Traits/SearchResultHelper.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 trait SearchResultHelper
 {
@@ -138,7 +139,7 @@ trait SearchResultHelper
         Criteria $criteria,
         SalesChannelContext $salesChannelContext,
     ): void {
-        $productCriteria = new Criteria();
+        $productCriteria = NostoCriteriaFactory::create();
         $productCriteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, [
             new EqualsFilter('productNumber', $query),
             new EqualsFilter('ean', $query),

--- a/src/Twig/Extension/NostoExtension.php
+++ b/src/Twig/Extension/NostoExtension.php
@@ -12,13 +12,13 @@ use Nosto\NostoIntegration\Model\Nosto\Entity\Category\Builder as CategoryBuilde
 use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\ProductProviderInterface;
 use Nosto\NostoIntegration\Utils\Logger\ContextHelper;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\NostoIntegration\Utils\ProductTaggingHelper;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -26,7 +26,6 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Throwable;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NostoExtension extends AbstractExtension
 {

--- a/src/Twig/Extension/NostoExtension.php
+++ b/src/Twig/Extension/NostoExtension.php
@@ -26,6 +26,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Throwable;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class NostoExtension extends AbstractExtension
 {
@@ -96,7 +97,7 @@ class NostoExtension extends AbstractExtension
 
     public function getShopwareProductByID($id, SalesChannelContext $context): ?SalesChannelProductEntity
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('id', $id));
 
         return $this->salesChannelProductRepository
@@ -110,7 +111,7 @@ class NostoExtension extends AbstractExtension
         SalesChannelContext $context,
         bool $isProductTagging = false,
     ): string|NostoProduct {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('id', $id));
         $criteria->addAssociation('children');
         /** @var ProductEntity $mainProduct */
@@ -119,7 +120,7 @@ class NostoExtension extends AbstractExtension
             ->first();
         /** @var ProductEntity $mainProduct */
         $variantFromDb = $this->productRepository
-            ->search(new Criteria([$variantId]), $context->getContext())
+            ->search(NostoCriteriaFactory::createWithIds([$variantId]), $context->getContext())
             ->first();
         $productTaggingHelper = new ProductTaggingHelper(
             $this->systemConfigService,
@@ -195,7 +196,7 @@ class NostoExtension extends AbstractExtension
         try {
             $categoryId = $category->getId();
 
-            $criteria = new Criteria([$categoryId]);
+            $criteria = NostoCriteriaFactory::createWithIds([$categoryId]);
             $criteria->addAssociation('seoUrls');
 
             $categoryWithSeo = $this->categoryRepository

--- a/src/Utils/Lifecycle.php
+++ b/src/Utils/Lifecycle.php
@@ -12,7 +12,6 @@ use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
@@ -23,7 +22,6 @@ use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Lifecycle
 {

--- a/src/Utils/Lifecycle.php
+++ b/src/Utils/Lifecycle.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 
 class Lifecycle
 {
@@ -90,7 +91,7 @@ class Lifecycle
 
     public function getNostoSorting(Context $context): ?ProductSortingEntity
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('key', RecommendationSortingHandler::MERCHANDISING_SORTING_KEY));
 
         return $this->sortingRepository->search($criteria, $context)->first();
@@ -145,7 +146,7 @@ class Lifecycle
 
     public function getDefaultSortingId(Context $context, string $key = null): ?string
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('configurationKey', $key));
         $sorting = $this->systemConfigRepository->search($criteria, $context)->first();
 
@@ -154,7 +155,7 @@ class Lifecycle
 
     public function getHighPrioritySortingId(Context $context): ?string
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new NotFilter(NotFilter::CONNECTION_AND, [
             new EqualsFilter('key', RecommendationSortingHandler::MERCHANDISING_SORTING_KEY),
             new EqualsFilter('key', ResolvedCriteriaProductSearchRoute::DEFAULT_SEARCH_SORT),
@@ -170,7 +171,7 @@ class Lifecycle
 
     public function getTopResultsSortingId(Context $context): ?string
     {
-        $criteria = new Criteria();
+        $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('key', ResolvedCriteriaProductSearchRoute::DEFAULT_SEARCH_SORT));
         $sorting = $this->sortingRepository->search($criteria, $context)->first();
 
@@ -240,7 +241,7 @@ class Lifecycle
 
     public function removeOldTags(Context $context): void
     {
-        $channelCriteria = new Criteria();
+        $channelCriteria = NostoCriteriaFactory::create();
         $channelCriteria->addFilter(
             new EqualsAnyFilter('typeId', [Defaults::SALES_CHANNEL_TYPE_STOREFRONT, Defaults::SALES_CHANNEL_TYPE_API]),
         );

--- a/src/Utils/NostoCriteriaFactory.php
+++ b/src/Utils/NostoCriteriaFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Utils;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+
+final class NostoCriteriaFactory
+{
+    private const PREFIX = 'Nosto.';
+    private const DEFAULT_TITLE = 'criteria';
+
+    public static function create(?string $title = null): Criteria
+    {
+        $criteria = new Criteria();
+        self::setTitle($criteria, $title ?? self::DEFAULT_TITLE);
+
+        return $criteria;
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    public static function createWithIds(array $ids, ?string $title = null): Criteria
+    {
+        $criteria = new Criteria($ids);
+        self::setTitle($criteria, $title ?? self::DEFAULT_TITLE);
+
+        return $criteria;
+    }
+
+    public static function setTitle(Criteria $criteria, string $title): void
+    {
+        if (!str_starts_with($title, self::PREFIX)) {
+            $title = self::PREFIX . $title;
+        }
+
+        $criteria->setTitle($title);
+    }
+}

--- a/src/Utils/NostoCriteriaFactory.php
+++ b/src/Utils/NostoCriteriaFactory.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 final class NostoCriteriaFactory
 {
     private const PREFIX = 'Nosto.';
+
     private const DEFAULT_TITLE = 'criteria';
 
     public static function create(?string $title = null): Criteria


### PR DESCRIPTION
1. Splitting sync per sales channel, so that multiple consumers can consume in parallel quicker. Adding caching for some data too
2. Removing eager load of child data, as we load it in the Builder.php as well this should reduce the load time
3. Added criteria factory and Nosto-prefixed titles for DAL queries
4. Add some extra criteria title for product_sync DAL queries