### PR TITLE
feat: product sync improvements

### DIFF
--- a/src/EventListener/ProductWrittenDeletedEvent.php
+++ b/src/EventListener/ProductWrittenDeletedEvent.php
@@ -84,9 +84,18 @@ class ProductWrittenDeletedEvent implements EventSubscriberInterface
 
     public function onProductWritten(EntityWrittenEvent $event): void
     {
-        $orderNumberMapping = $this->productHelper->loadOrderNumberMapping($event->getIds(), $event->getContext());
+        $orderNumberMapping = $this->productHelper->loadOrderNumberMapping(
+            $event->getIds(),
+            $event->getContext(),
+            fetchParents: true,
+        );
 
-        $this->writeEvents($event->getIds(), $event->getEntityName(), $event->getContext(), $orderNumberMapping);
+        $this->writeEvents(
+            array_keys($orderNumberMapping),
+            $event->getEntityName(),
+            $event->getContext(),
+            $orderNumberMapping,
+        );
     }
 
     public function beforeDelete(EntityDeleteEvent $event): void

--- a/src/Migration/Migration1770723920AddChangelogEntityIdIndex.php
+++ b/src/Migration/Migration1770723920AddChangelogEntityIdIndex.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1770723920AddChangelogEntityIdIndex extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1770723920;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $table = 'nosto_integration_entity_changelog';
+        $indexName = 'nosto_integration_entity_id_idx';
+
+        $exists = $connection->fetchOne(
+            'SELECT COUNT(1) FROM information_schema.statistics WHERE table_name = :table AND index_name = :index AND table_schema = DATABASE()',
+            [
+                'table' => $table,
+                'index' => $indexName,
+            ],
+        );
+
+        if ($exists) {
+            return;
+        }
+
+        // Create the index if it does not exist
+        $connection->executeStatement(
+            'CREATE INDEX ' . $indexName . ' ON ' . $table . ' (entity_id)',
+        );
+    }
+}

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -30,10 +30,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\CountAggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\CountResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -173,37 +173,27 @@ class ProductHelper
         $criteria->addAssociation('children.properties.group');
     }
 
+    /**
+     * @return iterable<EntitySearchResult<ProductCollection>>
+     */
     public function loadExistingParentProducts(
         array $existentParentProductIds,
         SalesChannelContext $context,
-    ): RepositoryIterator {
+    ): iterable {
         $shouldLog = $this->shouldLogExtra($context);
         $startedAt = $shouldLog ? microtime(true) : null;
         $salesChannelId = $context->getSalesChannelId();
         $languageId = $context->getLanguageId();
 
         $criteria = $this->getCommonCriteria('product_sync.productHelper.loadExistingParentProducts');
+        $criteria->setIds(array_unique(array_values($existentParentProductIds)));
         $criteria->addAssociation('children');
-        $criteria->setLimit(100);
 
         if (!$this->configProvider->isEnabledSyncInactiveProducts($salesChannelId, $languageId)) {
             $criteria->addFilter(new EqualsFilter('active', true));
         }
 
-        $categoryBlocklist = $this->configProvider->getCategoryBlocklist($salesChannelId, $languageId);
-        if (count($categoryBlocklist)) {
-            $criteria->addFilter(
-                new NotFilter(
-                    NotFilter::CONNECTION_AND,
-                    [new EqualsAnyFilter('product.categoriesRo.id', $categoryBlocklist)],
-                ),
-            );
-        }
-
-        $criteria->addFilter(new EqualsAnyFilter('id', array_unique(array_values($existentParentProductIds))));
         $this->eventDispatcher->dispatch(new ProductLoadExistingParentCriteriaEvent($criteria, $context));
-
-        $iterator = new RepositoryIterator($this->productRepository, $context->getContext(), $criteria);
 
         if ($shouldLog && $startedAt !== null) {
             $this->logDuration(
@@ -216,7 +206,12 @@ class ProductHelper
             );
         }
 
-        return $iterator;
+        return ProductRepositoryHelper::searchChunked(
+            $criteria,
+            100,
+            $context->getContext(),
+            $this->productRepository,
+        );
     }
 
     public function getProductsIterator(
@@ -233,7 +228,7 @@ class ProductHelper
         if (!$this->configProvider->isEnabledSyncInactiveProducts($salesChannelId, $languageId)) {
             $criteria->addFilter(new EqualsFilter('active', true));
         }
-
+        /*
         $categoryBlocklist = $this->configProvider->getCategoryBlocklist($salesChannelId, $languageId);
         if (count($categoryBlocklist)) {
             $criteria->addFilter(
@@ -243,7 +238,7 @@ class ProductHelper
                 ),
             );
         }
-
+        */
         $this->eventDispatcher->dispatch(new ProductLoadExistingCriteriaEvent($criteria, $context));
 
         return new RepositoryIterator($this->productRepository, $context->getContext(), $criteria);

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -18,6 +18,7 @@ use Nosto\NostoIntegration\Struct\FiltersExtension;
 use Nosto\NostoIntegration\Struct\IdToFieldMapping;
 use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
@@ -306,9 +307,15 @@ class ProductHelper
         return null;
     }
 
-    public function createRepositoryIterator(Criteria $criteria, Context $context): RepositoryIterator
+    /**
+     * @return iterable<iterable<ProductCollection>>
+     */
+    public function createRepositoryIterator(Criteria $criteria, Context $context): iterable
     {
-        return new RepositoryIterator($this->productRepository, $context, $criteria);
+        $iterator = new RepositoryIterator($this->productRepository, $context, $criteria);
+        while (($result = $iterator->fetch()) !== null) {
+            yield $result;
+        }
     }
 
     private function shouldLogExtra(SalesChannelContext $context): bool

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Nosto\NostoIntegration\Model\Nosto\Entity\Helper;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use Nosto\NostoIntegration\Enums\StockFieldOptions;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\Event\ProductLoadExistingCriteriaEvent;
@@ -17,7 +19,6 @@ use Nosto\NostoIntegration\Struct\IdToFieldMapping;
 use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Product\ProductEntity;
-use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionCollection;
@@ -32,6 +33,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\RequestContext;
@@ -41,8 +43,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class ProductHelper
 {
     public function __construct(
+        private readonly Connection $connection,
         private readonly EntityRepository $productRepository,
-        private readonly AbstractProductDetailRoute $productRoute,
         private readonly EntityRepository $reviewRepository,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ConfigProvider $configProvider,
@@ -249,18 +251,42 @@ class ProductHelper
     /**
      * @return array<string, string>
      */
-    public function loadOrderNumberMapping(array $ids, Context $context): array
+    public function loadOrderNumberMapping(array $ids, Context $context, bool $fetchParents = false): array
     {
-        $criteria = NostoCriteriaFactory::createWithIds($ids, 'product_sync.productHelper.loadOrderNumberMapping');
-        $iterator = new RepositoryIterator($this->productRepository, $context, $criteria);
-        $orderNumberMapping = [];
-        while (($result = $iterator->fetch()) !== null) {
-            foreach ($result as $product) {
-                $orderNumberMapping[$product->getId()] = $product->getProductNumber();
-            }
+        $query = $this->connection->createQueryBuilder();
+
+        $query
+            ->from('product', 'p')
+            ->where('p.id in (:ids)')
+            ->andWhere('p.version_id = :version_id')
+            ->setParameter('ids', Uuid::fromHexToBytesList($ids), ArrayParameterType::BINARY)
+            ->setParameter('version_id', Uuid::fromHexToBytes($context->getVersionId()));
+
+        if ($fetchParents) {
+            $query->select(
+                'LOWER(HEX(IFNULL(p.parent_id, p.id))) AS id',
+                'IFNULL(pp.product_number, p.product_number) AS productNumber',
+            );
+            $query->leftJoin('p', 'product', 'pp', 'pp.id = p.parent_id AND pp.version_id = p.parent_version_id');
+        } else {
+            $query->select(
+                'LOWER(HEX(p.id)) AS id',
+                'p.product_number AS productNumber',
+            );
         }
 
-        return $orderNumberMapping;
+        $result = [];
+        foreach ($query->executeQuery()->fetchAllAssociative() as $row) {
+            $id = $row['id'] ?? null;
+            $productNumber = $row['productNumber'] ?? null;
+            if (!is_string($id) || !is_string($productNumber)) {
+                continue;
+            }
+
+            $result[$id] = $productNumber;
+        }
+
+        return $result;
     }
 
     public function getProductUrl(ProductEntity $product, SalesChannelContext $context): ?string

--- a/src/Model/Nosto/Entity/Helper/ProductRepositoryHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductRepositoryHelper.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Model\Nosto\Entity\Helper;
+
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+
+class ProductRepositoryHelper
+{
+    /**
+     * @param EntityRepository<ProductCollection> $repository
+     * @return iterable<EntitySearchResult<ProductCollection>>
+     */
+    public static function searchChunked(
+        Criteria $criteria,
+        int $limit,
+        Context $context,
+        EntityRepository $repository,
+    ): iterable {
+        $ids = $criteria->getIds();
+        if (empty($ids)) {
+            return [];
+        }
+
+        foreach (array_chunk($ids, $limit) as $chunk) {
+            $criteria->setIds($chunk);
+            yield self::search($criteria, $context, $repository);
+        }
+    }
+
+    /**
+     * @param EntityRepository<ProductCollection> $repository
+     * @return EntitySearchResult<ProductCollection>
+     */
+    public static function search(
+        Criteria $criteria,
+        Context $context,
+        EntityRepository $repository,
+    ): EntitySearchResult {
+        if (!$criteria->hasAssociation('children')) {
+            return $repository->search($criteria, $context);
+        }
+
+        $childCriteria = $criteria->getAssociation('children');
+        $criteria->removeAssociation('children');
+
+        $parents = $repository->search($criteria, $context);
+        foreach ($parents->getEntities() as $parent) {
+            $parent->setChildren(new ProductCollection());
+        }
+
+        $parentIds = $parents->getIds();
+        $childCriteria->addFilter(new EqualsAnyFilter('parentId', $parentIds));
+        if ($criteria->getTitle()) {
+            $childCriteria->setTitle($criteria->getTitle() . '::associations::children');
+        }
+
+        $childCriteria->setLimit(100);
+
+        $repositoryIterator = new RepositoryIterator($repository, $context, $childCriteria);
+
+        $childProducts = new ProductCollection();
+        do {
+            $result = $repositoryIterator->fetch();
+            if ($result === null) {
+                break;
+            }
+
+            $childProducts->merge($result->getEntities());
+        } while ($result->count() > 0);
+
+        foreach ($childProducts as $childProduct) {
+            $parentId = $childProduct->getParentId();
+            $parent = $parents->get($parentId ?? '');
+            if (!$parent) {
+                continue;
+            }
+
+            $parent->getChildren()?->add($childProduct);
+        }
+
+        return $parents;
+    }
+}

--- a/src/Model/Nosto/Entity/Product/Builder.php
+++ b/src/Model/Nosto/Entity/Product/Builder.php
@@ -32,6 +32,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -69,6 +70,7 @@ class Builder
         private readonly CrossSellingBuilder $crossSellingBuilder,
         private readonly EntityRepository $tagRepository,
         private readonly SalesChannelRepository $categoryRepository,
+        private readonly EntityRepository $productRepository,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -683,47 +685,68 @@ class Builder
         SalesChannelProductEntity $product,
         SalesChannelContext $context,
     ): SkuCollection {
+        $children = $product->getChildren();
+        if (empty($children)) {
+            return new SkuCollection();
+        }
+
         $shouldLog = $this->shouldLogExtra($context);
         $startedAt = $shouldLog ? microtime(true) : null;
         $skuCollection = new SkuCollection();
 
-        if ($product->getChildren()->count()) {
-            $salesChannelId = $context->getSalesChannelId();
-            $languageId = $context->getLanguageId();
+        $salesChannelId = $context->getSalesChannelId();
+        $languageId = $context->getLanguageId();
 
-            $criteria = NostoCriteriaFactory::create('product_sync.builder.childrenSku');
-            $criteria->addAssociation('media');
-            $criteria->addAssociation('cover');
-            $criteria->addAssociation('options.group');
-            $criteria->addAssociation('properties.group');
-            $criteria->addAssociation('manufacturer');
-            $criteria->addAssociation('manufacturer.media');
-            $criteria->addAssociation('categoriesRo');
-            $criteria->addAssociation('visibilities');
-            $criteria->addFilter(new EqualsAnyFilter('id', $product->getChildren()->getIds()));
+        $criteria = NostoCriteriaFactory::create('product_sync.builder.childrenSku');
+        $criteria->addAssociation('media');
+        $criteria->addAssociation('cover');
+        $criteria->addAssociation('options.group');
+        $criteria->addAssociation('properties.group');
+        $criteria->addAssociation('manufacturer');
+        $criteria->addAssociation('manufacturer.media');
+        $criteria->addAssociation('categoriesRo');
+        $criteria->addAssociation('visibilities');
 
-            if (!$this->configProvider->isEnabledSyncInactiveProducts($salesChannelId, $languageId)) {
-                $criteria->addFilter(new EqualsFilter('active', true));
+        if (!$this->configProvider->isEnabledSyncInactiveProducts($salesChannelId, $languageId)) {
+            $criteria->addFilter(new EqualsFilter('active', true));
+        }
+
+        $categoryBlocklist = $this->configProvider->getCategoryBlocklist($salesChannelId, $languageId);
+        if (count($categoryBlocklist)) {
+            $criteria->addFilter(
+                new NotFilter(
+                    NotFilter::CONNECTION_AND,
+                    [new EqualsAnyFilter('product.categoriesRo.id', $categoryBlocklist)],
+                ),
+            );
+        }
+
+        foreach (array_chunk($product->getChildren()->getElements() ?? [], 50) as $children) {
+            $children = is_array($children) ? new EntityCollection($children) : $children;
+
+            $shopwareProducts = $this->productHelper->getShopwareProducts(
+                $children->getIds(),
+                $context,
+                true,
+            );
+
+            // Fetch non-visible products separately
+            $missingChildrenIds = array_diff($children->getIds(), $shopwareProducts->getIds());
+            $missingChildren = null;
+            if (!empty($missingChildrenIds)) {
+                $criteria->setIds($missingChildrenIds);
+                $missingChildren = $this->productRepository->search($criteria, $context->getContext())->getEntities();
             }
 
-            $categoryBlocklist = $this->configProvider->getCategoryBlocklist($salesChannelId, $languageId);
-            if (count($categoryBlocklist)) {
-                $criteria->addFilter(
-                    new NotFilter(
-                        NotFilter::CONNECTION_AND,
-                        [new EqualsAnyFilter('product.categoriesRo.id', $categoryBlocklist)],
-                    ),
+            foreach ($children as $variationProduct) {
+                $shopwareProduct = $shopwareProducts->get($variationProduct->getId()) ?? $missingChildren->get(
+                    $variationProduct->getId(),
                 );
-            }
-
-            $iterator = $this->productHelper->createRepositoryIterator($criteria, $context->getContext());
-
-            while (($children = $iterator->fetch()) !== null) {
-                $shopwareProducts = $this->productHelper->getShopwareProducts($children->getIds(), $context);
-                foreach ($children as $variationProduct) {
-                    $shopwareProduct = $shopwareProducts->get($variationProduct->getId());
-                    $skuCollection->append($this->skuBuilder->build($shopwareProduct ?: $variationProduct, $context));
+                if (!$shopwareProduct) {
+                    continue;
                 }
+
+                $skuCollection->append($this->skuBuilder->build($shopwareProduct, $context));
             }
         }
 

--- a/src/Model/Nosto/Entity/Product/SkuBuilder.php
+++ b/src/Model/Nosto/Entity/Product/SkuBuilder.php
@@ -142,7 +142,7 @@ class SkuBuilder
             $nostoSku->addCustomField('variant-listing-config', json_encode($product->getVariantListingConfig()));
         }
 
-        foreach ($product->getVisibilities() as $visibility) {
+        foreach ($product->getVisibilities() ?? [] as $visibility) {
             if ($channelId === $visibility->getSalesChannelId()) {
                 switch ($visibility->getVisibility()) {
                     case ProductVisibilityDefinition::VISIBILITY_ALL:

--- a/src/Model/Operation/EntityChangelogSyncHandler.php
+++ b/src/Model/Operation/EntityChangelogSyncHandler.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Nosto\NostoIntegration\Model\Operation;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use Nosto\NostoIntegration\Async\CategorySyncMessage;
 use Nosto\NostoIntegration\Async\EntityChangelogSyncMessage;
 use Nosto\NostoIntegration\Async\EventsWriter;
 use Nosto\NostoIntegration\Async\MarketingPermissionSyncMessage;
 use Nosto\NostoIntegration\Async\OrderSyncMessage;
 use Nosto\NostoIntegration\Async\ProductSyncMessage;
-use Nosto\NostoIntegration\Entity\Changelog\ChangelogEntity;
+use Nosto\NostoIntegration\Entity\Changelog\ChangelogDefinition;
 use Nosto\NostoIntegration\Model\ConfigProvider;
 use Nosto\NostoIntegration\Model\Nosto\Account\Provider as AccountProvider;
 use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
@@ -19,8 +21,6 @@ use Nosto\Scheduler\Model\JobScheduler;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -32,7 +32,7 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
     private const BATCH_SIZE = 100;
 
     public function __construct(
-        private readonly EntityRepository $entityChangelogRepository,
+        private readonly Connection $connection,
         private readonly JobScheduler $jobScheduler,
         private readonly ConfigProvider $configProvider,
         private readonly AccountProvider $accountProvider,
@@ -92,39 +92,70 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
         string $metricPrefix,
         callable $processCallback,
     ): void {
+        $query = $this->connection->createQueryBuilder()
+            ->select(
+                'LOWER(HEX(entity_id)) as entityId',
+                'MIN(product_number) as productNumber',
+            )
+            ->from(ChangelogDefinition::ENTITY_NAME)
+            ->where('entity_type = :entityType')
+            ->setParameter('entityType', $entityType)
+            ->orderBy('created_at', 'ASC')
+            ->groupBy('entity_id')
+            ->setMaxResults(self::BATCH_SIZE);
+
         $criteria = NostoCriteriaFactory::create($metricPrefix . '.delete');
         $criteria->addFilter(new EqualsFilter('entityType', $entityType));
         $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING));
         $criteria->setLimit(self::BATCH_SIZE);
 
-        $iterator = new RepositoryIterator($this->entityChangelogRepository, $context, $criteria);
         $shouldLogExtra = $this->shouldLogExtra();
         $batchIndex = 0;
         $eventCount = 0;
         $payloadCount = 0;
         $iteratorStartedAt = $shouldLogExtra ? microtime(true) : null;
 
-        while (($events = $iterator->fetch()) !== null) {
+        do {
             ++$batchIndex;
             $batchStartedAt = $shouldLogExtra ? microtime(true) : null;
-            $ids = $entityType === ProductDefinition::ENTITY_NAME || $entityType === 'order_placed' ?
-                $events->reduce(static function (array $result, ChangelogEntity $event): array {
-                    $result[$event->getEntityId()] = $event->getProductNumber();
-                    return $result;
-                }, []) :
-                $events->map(static fn (ChangelogEntity $event): string => $event->getEntityId());
 
-            $batchEventCount = $events->count();
+            $ids = [];
+
+            $rows = $query->executeQuery()->fetchAllAssociative();
+
+            foreach ($rows as $row) {
+                $entityId = $row['entityId'] ?? null;
+                if (!is_string($entityId)) {
+                    continue;
+                }
+
+                if ($entityType !== ProductDefinition::ENTITY_NAME && $entityType !== 'order_placed') {
+                    $ids[$entityId] = $entityId;
+                    continue;
+                }
+
+                $ids[$entityId] = $row['productNumber'] ?? $entityId;
+            }
+
+            $batchEventCount = count($rows);
             $batchPayloadCount = count($ids);
             $eventCount += $batchEventCount;
             $payloadCount += $batchPayloadCount;
 
+            if (empty($ids)) {
+                continue;
+            }
+
             $processCallback($ids);
-            $deleteDataSet = array_map(static fn ($id): array => [
-                'id' => $id,
-            ], array_values($events->getIds()));
+
             $deleteStartedAt = $shouldLogExtra ? microtime(true) : null;
-            $this->entityChangelogRepository->delete($deleteDataSet, $context);
+            $this->connection->createQueryBuilder()
+                ->delete(ChangelogDefinition::ENTITY_NAME)
+                ->where('entity_type = :entityType')
+                ->andWhere('entity_id IN (:ids)')
+                ->setParameter('entityType', $entityType)
+                ->setParameter('ids', Uuid::fromHexToBytesList(array_keys($ids)), ArrayParameterType::BINARY)
+                ->executeStatement();
 
             if ($shouldLogExtra && $deleteStartedAt !== null) {
                 $this->logDuration(
@@ -150,7 +181,7 @@ class EntityChangelogSyncHandler implements JobHandlerInterface, GeneratingHandl
                     ],
                 );
             }
-        }
+        } while (!empty($ids));
 
         if ($shouldLogExtra && $iteratorStartedAt !== null && $batchIndex > 0) {
             $this->logDuration(

--- a/src/Model/Operation/FullCatalogSyncHandler.php
+++ b/src/Model/Operation/FullCatalogSyncHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Nosto\NostoIntegration\Model\Operation;
 
+use Doctrine\DBAL\Connection;
 use Nosto\NostoIntegration\Async\CategorySyncMessage;
 use Nosto\NostoIntegration\Async\FullCatalogSyncMessage;
 use Nosto\NostoIntegration\Async\ProductSyncMessage;
@@ -18,7 +19,6 @@ use Nosto\Scheduler\Model\JobScheduler;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\{EqualsFilter, NotFilter};
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -30,7 +30,7 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
     private const BATCH_SIZE = 150;
 
     public function __construct(
-        private readonly EntityRepository $productRepository,
+        private readonly Connection $connection,
         private readonly EntityRepository $categoryRepository,
         private readonly JobScheduler $jobScheduler,
         private readonly ConfigProvider $configProvider,
@@ -46,16 +46,10 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
     {
         $context = $message->getContext();
         $size = $this->configProvider->getBatchSize();
+        $size = ($size < 1) ? self::BATCH_SIZE : $size;
         $shouldLogExtra = $this->shouldLogExtra();
         $syncStartedAt = $shouldLogExtra ? microtime(true) : null;
         $result = new JobResult();
-        $criteriaProduct = NostoCriteriaFactory::create('product_sync.full_catalog.products');
-        $criteriaProduct->setLimit($size ? $size : self::BATCH_SIZE);
-        $productRepositoryIterator = new RepositoryIterator(
-            $this->productRepository,
-            $message->getContext(),
-            $criteriaProduct,
-        );
         $result->addMessage(new InfoMessage('Child job generation started.'));
 
         $productBatchCount = 0;
@@ -63,12 +57,12 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
         $productsStartedAt = $shouldLogExtra ? microtime(true) : null;
         $accounts = $this->accountProvider->all($context);
 
-        while (($products = $productRepositoryIterator->fetch()) !== null) {
+        foreach ($this->fetchParentProducts($size, $context) as $ids) {
             ++$productBatchCount;
             $batchStartedAt = $shouldLogExtra ? microtime(true) : null;
-            $ids = $this->getProductIdsForMessage($products->getEntities());
             $batchSize = count($ids);
             $productCount += $batchSize;
+
             foreach ($accounts as $account) {
                 $this->jobScheduler->schedule(
                     new ProductSyncMessage(
@@ -103,6 +97,7 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
                 );
             }
         }
+
         if ($shouldLogExtra && $productsStartedAt !== null && $productBatchCount > 0) {
             $this->logDuration(
                 $context,
@@ -128,10 +123,10 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
         $categoryBatchCount = 0;
         $categoryCount = 0;
         $categoriesStartedAt = $shouldLogExtra ? microtime(true) : null;
-        while (($categories = $categoryRepositoryIterator->fetch()) !== null) {
+        while (($categoryIds = $categoryRepositoryIterator->fetchIds()) !== null) {
             ++$categoryBatchCount;
             $batchStartedAt = $shouldLogExtra ? microtime(true) : null;
-            $ids = $this->getCategoryIdsForMessage($categories->getEntities());
+            $ids = array_combine($categoryIds, $categoryIds);
             $batchSize = count($ids);
             $categoryCount += $batchSize;
             $this->jobScheduler->schedule(
@@ -185,27 +180,43 @@ class FullCatalogSyncHandler implements JobHandlerInterface, GeneratingHandlerIn
     }
 
     /**
-     * @return array<string, string>
+     * @return iterable<array<string, string>>
      */
-    private function getProductIdsForMessage(EntityCollection $products): array
+    protected function fetchParentProducts(int $batchSize, Context $context): iterable
     {
-        $data = [];
-        foreach ($products as $product) {
-            $data[$product->getId()] = $product->getProductNumber();
-        }
-        return $data;
-    }
+        $query = $this->connection->createQueryBuilder()
+            ->select(
+                'LOWER(HEX(p.id)) AS id',
+                'p.product_number AS productNumber',
+            )
+            ->from('product', 'p')
+            ->where('p.parent_id IS NULL')
+            ->andWhere('p.version_id = :version_id')
+            ->setParameter('version_id', Uuid::fromHexToBytes($context->getVersionId()))
+            ->setMaxResults($batchSize);
 
-    /**
-     * @return array<string, string>
-     */
-    private function getCategoryIdsForMessage(EntityCollection $categories): array
-    {
-        $data = [];
-        foreach ($categories as $category) {
-            $data[$category->getId()] = $category->getId();
-        }
-        return $data;
+        $offset = 0;
+        do {
+            $query->setFirstResult($offset);
+
+            $queryResult = $query->executeQuery();
+            $offset += $queryResult->rowCount();
+
+            $result = [];
+            foreach ($queryResult->fetchAllAssociative() as $row) {
+                $id = $row['id'] ?? null;
+                $productNumber = $row['productNumber'] ?? null;
+                if (!is_string($id) || !is_string($productNumber)) {
+                    continue;
+                }
+
+                $result[$id] = $productNumber;
+            }
+
+            if (!empty($result)) {
+                yield $result;
+            }
+        } while ($queryResult->rowCount() > 0);
     }
 
     private function shouldLogExtra(): bool

--- a/src/Model/Operation/ProductSyncHandler.php
+++ b/src/Model/Operation/ProductSyncHandler.php
@@ -156,12 +156,12 @@ class ProductSyncHandler implements Job\JobHandlerInterface
 
         $deletedProductIds = array_diff($productIds, array_keys($existentProducts));
 
-        $parentProductIterator = $this->productHelper->loadExistingParentProducts($existentProducts, $context);
+        $parentProducts = $this->productHelper->loadExistingParentProducts($existentProducts, $context);
         $parentFetchStartedAt = $shouldLogExtra ? microtime(true) : null;
         $processedParentCount = 0;
 
-        while (($products = $parentProductIterator->fetch()) !== null) {
-            $productCollection = $products->getEntities();
+        foreach ($parentProducts as $searchResult) {
+            $productCollection = $searchResult->getEntities();
             $this->doUpsertOperation($account, $context, $productCollection, $result, $ids);
             $processedParentCount += $productCollection->count();
         }
@@ -322,7 +322,7 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         // === Pass 2: Single batched DB query ===
         $shopwareProductsFetchStartedAt = $shouldLogExtra ? microtime(true) : null;
         $allShopwareProducts = !empty($allUniqueIds)
-            ? $this->productHelper->getShopwareProducts(array_keys($allUniqueIds), $context)
+            ? $this->productHelper->getShopwareProducts(array_keys($allUniqueIds), $context, true)
             : new ProductCollection();
         if ($shouldLogExtra && $shopwareProductsFetchStartedAt !== null) {
             $this->logDuration(

--- a/src/Resources/config/imports/search.xml
+++ b/src/Resources/config/imports/search.xml
@@ -29,34 +29,10 @@
         </service>
 
         <service
-            id="Shopware\Storefront\Page\Search\SearchPageLoader"
-            public="true"
-            autowire="true"
-        >
-            <argument
-                type="service"
-                key="$genericLoader"
-                id="Shopware\Storefront\Page\GenericPageLoader"
-                on-invalid="null"
-            />
-            <argument
-                type="service"
-                key="$productSearchRoute"
-                id="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute"
-                on-invalid="null"
-            />
-            <argument
-                type="service"
-                key="$translator"
-                id="Shopware\Core\Framework\Adapter\Translation\Translator"
-            />
-        </service>
-
-        <service
             id="Nosto\NostoIntegration\Decorator\Core\Content\Product\SalesChannel\Search\ProductSearchRoute"
             decorates="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute"
             decoration-on-invalid="ignore"
-            decoration-priority="-1000"
+            decoration-priority="-100000"
             autowire="true"
         >
             <argument type="service" key="$salesChannelProductRepository" id="sales_channel.product.repository" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -16,7 +16,7 @@
         <service id="Nosto\NostoIntegration\Model\Operation\FullCatalogSyncHandler">
             <tag name="nosto.job_handler" code="nosto-integration-full-catalog-sync"/>
 
-            <argument key="$productRepository" type="service" id="product.repository"/>
+            <argument key="$connection" type="service" id="Doctrine\DBAL\Connection"/>
             <argument key="$categoryRepository" type="service" id="category.repository"/>
             <argument key="$accountProvider" type="service" id="Nosto\NostoIntegration\Model\Nosto\Account\Provider"/>
             <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
@@ -53,8 +53,6 @@
         <service id="Nosto\NostoIntegration\Model\Operation\EntityChangelogSyncHandler">
             <tag name="nosto.job_handler" code="nosto-integration-entity-changelog-sync"/>
 
-            <argument key="$entityChangelogRepository" type="service"
-                      id="nosto_integration_entity_changelog.repository"/>
             <argument key="$accountProvider" type="service" id="Nosto\NostoIntegration\Model\Nosto\Account\Provider"/>
             <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
         </service>
@@ -108,8 +106,6 @@
 
         <service id="Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper">
             <argument key="$productRepository" type="service" id="product.repository"/>
-            <argument key="$productRoute" type="service"
-                      id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute"/>
             <argument key="$reviewRepository" type="service" id="product_review.repository"/>
             <argument key="$eventDispatcher" type="service" id="event_dispatcher"/>
             <argument key="$configProvider" type="service" id="Nosto\NostoIntegration\Model\ConfigProvider"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -28,7 +28,7 @@
             <argument key="$channelContextFactory" type="service"
                       id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
             <argument key="$productProvider" type="service"
-                      id="Nosto\NostoIntegration\Model\Nosto\Entity\Product\CachedProvider"/>
+                      id="Nosto\NostoIntegration\Model\Nosto\Entity\Product\Provider"/>
             <argument key="$ruleLoader" type="service" id="Shopware\Core\Checkout\Cart\RuleLoader"/>
             <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
         </service>

--- a/src/Service/ScheduledTask/EntityChangelogScheduledTaskHandler.php
+++ b/src/Service/ScheduledTask/EntityChangelogScheduledTaskHandler.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\Service\ScheduledTask;
 
 use Nosto\NostoIntegration\Async\EntityChangelogSyncMessage;
+use Nosto\NostoIntegration\Model\Operation\EntityChangelogSyncHandler;
 use Nosto\Scheduler\Model\Job\GeneratingHandlerInterface;
 use Nosto\Scheduler\Model\JobScheduler;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -20,12 +24,25 @@ class EntityChangelogScheduledTaskHandler extends ScheduledTaskHandler implement
         EntityRepository $scheduledTaskRepository,
         private readonly JobScheduler $jobScheduler,
         private readonly LoggerInterface $logger,
+        private readonly EntityRepository $nostoSchedulerJobRepository,
     ) {
         parent::__construct($scheduledTaskRepository, $this->logger);
     }
 
     public function run(): void
     {
+        $context = Context::createCLIContext();
+        $criteria = (new Criteria())
+            ->addFilter(new EqualsFilter('type', EntityChangelogSyncHandler::HANDLER_CODE))
+            ->addFilter(new EqualsFilter('status', 'pending'))
+            ->addFilter(new EqualsFilter('parentId', null))
+            ->setLimit(1);
+
+        // Only dispatch a new task if there is none pending
+        if ($this->nostoSchedulerJobRepository->searchIds($criteria, $context)->firstId()) {
+            return;
+        }
+
         $jobMessage = new EntityChangelogSyncMessage(Uuid::randomHex());
         $this->jobScheduler->schedule($jobMessage);
     }


### PR DESCRIPTION
## Changes made

### `feat: optimize entity changelog and full catalog sync`
- Change entity changelog sync to now group the changes by entity id. This removed multiple syncs for the same entity
- Change product full to only use parent products (child products will be synced automatically)
- when a product is written, index the parent product, if one exists

### `feat: optimize product sync`
- do not use cached data during product sync
- process child products in smaller batches
- only fetch child products via the normal product repository if they cannot be fetched via the sales channel repository

### `fix: do not override SearchPageLoader, fix decoration priority`
- this prevents SwagCommercial from breaking if the Nosto search is not active for the current search