### PR TITLE
Fix/partial entity children conversion

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 5.2.8
+* Fix: PartialEntity-Children zu PartialProduct konvertieren, um fatale Fehler auf Produktdetailseiten zu verhindern
+
 # 5.2.7
 * Fix: php-sdk Abhängigkeit Aktualisierung
 

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,6 @@
+# 5.2.8
+* Fix: Convert PartialEntity children to PartialProduct to prevent fatal errors on product detail pages
+
 # 5.2.7
 * Fix: update php-sdk dependency
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "nosto/nosto-integration",
     "description": "Nosto Integration",
     "type": "shopware-platform-plugin",
-    "version": "5.2.7",
+    "version": "5.2.8",
     "license": "OSL-3.0",
     "authors": [
         {

--- a/src/Model/Nosto/Entity/Product/PartialProduct.php
+++ b/src/Model/Nosto/Entity/Product/PartialProduct.php
@@ -206,10 +206,14 @@ class PartialProduct
         return null;
     }
 
-    public function getChildren(): ?EntityCollection
+    public function getChildren(): ?PartialProductCollection
     {
         $value = $this->entity->get('children');
-        return $value instanceof EntityCollection ? $value : null;
+        if (!$value instanceof EntityCollection) {
+            return null;
+        }
+
+        return PartialProductConverter::toPartialProductCollection($value);
     }
 
     public function getCategoriesRo(): ?EntityCollection


### PR DESCRIPTION
## Fix PartialEntity children not converted to PartialProduct

PartialProduct::getChildren() returned raw PartialEntity objects from the EntityCollection. Methods like getDisplayGroup(), getActive(), etc. are not available on PartialEntity, causing fatal errors on product detail pages when product tagging iterates over children.

Convert children to PartialProductCollection via PartialProductConverter to ensure all child entities are wrapped as PartialProduct instances.