### PR TITLE
Run dependency migrations on install and update as well as activate

### DIFF
--- a/src/NostoIntegration.php
+++ b/src/NostoIntegration.php
@@ -31,12 +31,14 @@ class NostoIntegration extends Plugin
     {
         (new Utils\Lifecycle($this->container, true))->install($installContext);
         parent::install($installContext);
+        $this->migrateDependencyBundles();
     }
 
     public function update(UpdateContext $updateContext): void
     {
         (new Utils\Lifecycle($this->container, true))->update($updateContext);
         parent::update($updateContext);
+        $this->migrateDependencyBundles();
     }
 
     public function deactivate(DeactivateContext $deactivateContext): void
@@ -49,13 +51,27 @@ class NostoIntegration extends Plugin
     {
         (new Utils\Lifecycle($this->container, true))->activate($activateContext);
         parent::activate($activateContext);
+        $this->migrateDependencyBundles();
+        $this->copyDependencyBundleAssets();
+    }
+
+    private function migrateDependencyBundles(): void
+    {
         /** @var AssetService $assetService */
-        $assetService = $this->container->get('nosto.plugin.assetservice.public');
         /** @var Utils\MigrationHelper $migrationHelper */
         $migrationHelper = $this->container->get(Utils\MigrationHelper::class);
 
         foreach ($this->getDependencyBundles() as $bundle) {
             $migrationHelper->getMigrationCollection($bundle)->migrateInPlace();
+        }
+    }
+
+    private function copyDependencyBundleAssets(): void
+    {
+        /** @var AssetService $assetService */
+        $assetService = $this->container->get('nosto.plugin.assetservice.public');
+
+        foreach ($this->getDependencyBundles() as $bundle) {
             $assetService->copyAssetsFromBundle((new ReflectionClass($bundle))->getShortName());
         }
     }

--- a/src/NostoIntegration.php
+++ b/src/NostoIntegration.php
@@ -8,6 +8,7 @@ use Composer\Autoload\ClassLoader;
 use Nosto\Scheduler\NostoScheduler;
 use ReflectionClass;
 use Shopware\Core\Framework\Bundle;
+use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Parameter\AdditionalBundleParameters;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
@@ -57,9 +58,9 @@ class NostoIntegration extends Plugin
 
     private function migrateDependencyBundles(): void
     {
-        /** @var AssetService $assetService */
-        /** @var Utils\MigrationHelper $migrationHelper */
-        $migrationHelper = $this->container->get(Utils\MigrationHelper::class);
+        $migrationHelper = new Utils\MigrationHelper(
+            $this->container->get(MigrationCollectionLoader::class),
+        );
 
         foreach ($this->getDependencyBundles() as $bundle) {
             $migrationHelper->getMigrationCollection($bundle)->migrateInPlace();

--- a/src/NostoIntegration.php
+++ b/src/NostoIntegration.php
@@ -32,14 +32,16 @@ class NostoIntegration extends Plugin
     {
         (new Utils\Lifecycle($this->container, true))->install($installContext);
         parent::install($installContext);
-        $this->migrateDependencyBundles();
+        $bundles = $this->getDependencyBundles();
+        $this->migrateDependencyBundles($bundles);
     }
 
     public function update(UpdateContext $updateContext): void
     {
         (new Utils\Lifecycle($this->container, true))->update($updateContext);
         parent::update($updateContext);
-        $this->migrateDependencyBundles();
+        $bundles = $this->getDependencyBundles();
+        $this->migrateDependencyBundles($bundles);
     }
 
     public function deactivate(DeactivateContext $deactivateContext): void
@@ -52,15 +54,19 @@ class NostoIntegration extends Plugin
     {
         (new Utils\Lifecycle($this->container, true))->activate($activateContext);
         parent::activate($activateContext);
-        $this->migrateDependencyBundles();
-        $this->copyDependencyBundleAssets();
+        $bundles = $this->getDependencyBundles();
+        $this->migrateDependencyBundles($bundles);
+        $this->copyDependencyBundleAssets($bundles);
     }
 
-    private function migrateDependencyBundles(): void
+    /**
+     * @param Bundle[] $bundles
+     */
+    private function migrateDependencyBundles(array $bundles): void
     {
         $migrationHelper = $this->createMigrationHelper();
 
-        foreach ($this->getDependencyBundles() as $bundle) {
+        foreach ($bundles as $bundle) {
             $migrationHelper->getMigrationCollection($bundle)->migrateInPlace();
         }
     }
@@ -72,12 +78,15 @@ class NostoIntegration extends Plugin
         );
     }
 
-    protected function copyDependencyBundleAssets(): void
+    /**
+     * @param Bundle[] $bundles
+     */
+    protected function copyDependencyBundleAssets(array $bundles): void
     {
         /** @var AssetService $assetService */
         $assetService = $this->container->get('nosto.plugin.assetservice.public');
 
-        foreach ($this->getDependencyBundles() as $bundle) {
+        foreach ($bundles as $bundle) {
             $assetService->copyAssetsFromBundle((new ReflectionClass($bundle))->getShortName());
         }
     }

--- a/src/NostoIntegration.php
+++ b/src/NostoIntegration.php
@@ -82,6 +82,8 @@ class NostoIntegration extends Plugin
      */
     private function getDependencyBundles(): array
     {
+        self::classLoader();
+
         return [
             new NostoScheduler(),
         ];

--- a/src/NostoIntegration.php
+++ b/src/NostoIntegration.php
@@ -123,8 +123,6 @@ class NostoIntegration extends Plugin
      */
     public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
     {
-        self::classLoader();
-
         return $this->getDependencyBundles();
     }
 

--- a/src/NostoIntegration.php
+++ b/src/NostoIntegration.php
@@ -58,16 +58,21 @@ class NostoIntegration extends Plugin
 
     private function migrateDependencyBundles(): void
     {
-        $migrationHelper = new Utils\MigrationHelper(
-            $this->container->get(MigrationCollectionLoader::class),
-        );
+        $migrationHelper = $this->createMigrationHelper();
 
         foreach ($this->getDependencyBundles() as $bundle) {
             $migrationHelper->getMigrationCollection($bundle)->migrateInPlace();
         }
     }
 
-    private function copyDependencyBundleAssets(): void
+    protected function createMigrationHelper(): Utils\MigrationHelper
+    {
+        return new Utils\MigrationHelper(
+            $this->container->get(MigrationCollectionLoader::class),
+        );
+    }
+
+    protected function copyDependencyBundleAssets(): void
     {
         /** @var AssetService $assetService */
         $assetService = $this->container->get('nosto.plugin.assetservice.public');

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -45,7 +45,7 @@ class NostoIntegrationTest extends TestCase
 
     public function testDependencyBundleAssetsAreCopiedOnActivation(): void
     {
-        $plugin = $this->createPluginMock(false);
+        $plugin = $this->createPluginMock();
 
         $assetService = $this->getMockBuilder(AssetService::class)
             ->disableOriginalConstructor()
@@ -64,7 +64,7 @@ class NostoIntegrationTest extends TestCase
         $plugin->activate($activateContext);
     }
 
-    private function createPluginMock(bool $mockAssetCopy = true): NostoIntegration
+    private function createPluginMock(): NostoIntegration
     {
         $migrationCollection = $this->getMockBuilder(MigrationCollection::class)
             ->disableOriginalConstructor()
@@ -87,19 +87,12 @@ class NostoIntegrationTest extends TestCase
                 'custom/plugins/nosto-shopware6',
                 $this->getContainer()->getParameter('kernel.project_dir'),
             ])
-            ->onlyMethods(
-                $mockAssetCopy ? ['createMigrationHelper', 'copyDependencyBundleAssets'] : ['createMigrationHelper'],
-            )
+            ->onlyMethods(['createMigrationHelper'])
             ->getMock();
 
         $plugin->expects($this->once())
             ->method('createMigrationHelper')
             ->willReturn($migrationHelper);
-
-        if ($mockAssetCopy) {
-            $plugin->expects($this->never())
-                ->method('copyDependencyBundleAssets');
-        }
 
         $plugin->setContainer($this->getContainer());
 

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\Tests;
 
 use Nosto\NostoIntegration\NostoIntegration;
-use Nosto\Scheduler\NostoScheduler;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 use Shopware\Core\Framework\Plugin\Util\AssetService;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
@@ -20,23 +22,7 @@ class NostoIntegrationTest extends TestCase
     {
         /** @var NostoIntegration $nostoIntegration */
         $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
-
-        $migrationCollection = $this->getMockBuilder(MigrationCollection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $migrationCollection->expects($this->once())
-            ->method('sync');
-
-        $migrationLoader = $this->getMockBuilder(MigrationCollectionLoader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $migrationLoader->expects($this->once())
-            ->method('addSource');
-        $migrationLoader->expects($this->once())
-            ->method('collect')
-            ->with('NostoScheduler')
-            ->willReturn($migrationCollection);
-        $this->getContainer()->set(MigrationCollectionLoader::class, $migrationLoader);
+        $this->mockDependencyMigrationExecution();
 
         $assetService = $this->getMockBuilder(AssetService::class)
             ->disableOriginalConstructor()
@@ -53,5 +39,58 @@ class NostoIntegrationTest extends TestCase
         $activateContext->method('getContext')->willReturn(Context::createDefaultContext());
 
         $nostoIntegration->activate($activateContext);
+    }
+
+    public function testNostoSchedulerMigrationsRunOnInstall(): void
+    {
+        /** @var NostoIntegration $nostoIntegration */
+        $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
+        $this->mockDependencyMigrationExecution();
+
+        $installContext = $this->getMockBuilder(InstallContext::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getContext'])
+            ->getMock();
+        $installContext->method('getContext')->willReturn(Context::createDefaultContext());
+
+        $nostoIntegration->install($installContext);
+    }
+
+    public function testNostoSchedulerMigrationsRunOnUpdate(): void
+    {
+        /** @var NostoIntegration $nostoIntegration */
+        $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
+        $this->mockDependencyMigrationExecution();
+
+        $updateContext = $this->getMockBuilder(UpdateContext::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getContext', 'getCurrentPluginVersion'])
+            ->getMock();
+        $updateContext->method('getContext')->willReturn(Context::createDefaultContext());
+        $updateContext->method('getCurrentPluginVersion')->willReturn('5.2.9');
+
+        $nostoIntegration->update($updateContext);
+    }
+
+    private function mockDependencyMigrationExecution(): void
+    {
+        $migrationCollection = $this->getMockBuilder(MigrationCollection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $migrationCollection->expects($this->once())
+            ->method('sync');
+        $migrationCollection->expects($this->once())
+            ->method('migrateInPlace');
+
+        $migrationLoader = $this->getMockBuilder(MigrationCollectionLoader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $migrationLoader->expects($this->once())
+            ->method('addSource');
+        $migrationLoader->expects($this->once())
+            ->method('collect')
+            ->with('NostoScheduler')
+            ->willReturn($migrationCollection);
+        $this->getContainer()->set(MigrationCollectionLoader::class, $migrationLoader);
     }
 }

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -38,7 +38,7 @@ class NostoIntegrationTest extends TestCase
             ->onlyMethods(['getContext', 'getCurrentPluginVersion'])
             ->getMock();
         $updateContext->method('getContext')->willReturn(Context::createDefaultContext());
-        $updateContext->method('getCurrentPluginVersion')->willReturn('5.2.9');
+        $updateContext->method('getCurrentPluginVersion')->willReturn('1.0.0');
 
         $plugin->update($updateContext);
     }

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -20,9 +20,10 @@ class NostoIntegrationTest extends TestCase
 
     public function testNostoSchedulerIsAddedOnActivation(): void
     {
+        $this->mockDependencyMigrationExecution();
+
         /** @var NostoIntegration $nostoIntegration */
         $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
-        $this->mockDependencyMigrationExecution();
 
         $assetService = $this->getMockBuilder(AssetService::class)
             ->disableOriginalConstructor()
@@ -43,9 +44,10 @@ class NostoIntegrationTest extends TestCase
 
     public function testNostoSchedulerMigrationsRunOnInstall(): void
     {
+        $this->mockDependencyMigrationExecution();
+
         /** @var NostoIntegration $nostoIntegration */
         $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
-        $this->mockDependencyMigrationExecution();
 
         $installContext = $this->getMockBuilder(InstallContext::class)
             ->disableOriginalConstructor()
@@ -58,9 +60,10 @@ class NostoIntegrationTest extends TestCase
 
     public function testNostoSchedulerMigrationsRunOnUpdate(): void
     {
+        $this->mockDependencyMigrationExecution();
+
         /** @var NostoIntegration $nostoIntegration */
         $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
-        $this->mockDependencyMigrationExecution();
 
         $updateContext = $this->getMockBuilder(UpdateContext::class)
             ->disableOriginalConstructor()

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -18,6 +18,13 @@ class NostoIntegrationTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
+    protected function tearDown(): void
+    {
+        static::ensureKernelShutdown();
+
+        parent::tearDown();
+    }
+
     public function testNostoSchedulerIsAddedOnActivation(): void
     {
         $this->mockDependencyMigrationExecution();

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
 use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
+use Shopware\Core\Framework\Plugin\Util\AssetService;
 
 class NostoIntegrationTest extends TestCase
 {
@@ -42,11 +43,17 @@ class NostoIntegrationTest extends TestCase
         $plugin->update($updateContext);
     }
 
-    public function testNostoSchedulerIsAddedOnActivation(): void
+    public function testDependencyBundleAssetsAreCopiedOnActivation(): void
     {
-        $plugin = $this->createPluginMock();
-        $plugin->expects($this->once())
-            ->method('copyDependencyBundleAssets');
+        $plugin = $this->createPluginMock(false);
+
+        $assetService = $this->getMockBuilder(AssetService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $assetService->expects($this->once())
+            ->method('copyAssetsFromBundle')
+            ->with('NostoScheduler');
+        $this->getContainer()->set('nosto.plugin.assetservice.public', $assetService);
 
         $activateContext = $this->getMockBuilder(ActivateContext::class)
             ->disableOriginalConstructor()
@@ -57,7 +64,7 @@ class NostoIntegrationTest extends TestCase
         $plugin->activate($activateContext);
     }
 
-    private function createPluginMock(): NostoIntegration
+    private function createPluginMock(bool $mockAssetCopy = true): NostoIntegration
     {
         $migrationCollection = $this->getMockBuilder(MigrationCollection::class)
             ->disableOriginalConstructor()
@@ -80,12 +87,18 @@ class NostoIntegrationTest extends TestCase
                 'custom/plugins/nosto-shopware6',
                 $this->getContainer()->getParameter('kernel.project_dir'),
             ])
-            ->onlyMethods(['createMigrationHelper', 'copyDependencyBundleAssets'])
+            ->onlyMethods($mockAssetCopy ? ['createMigrationHelper', 'copyDependencyBundleAssets'] : ['createMigrationHelper'])
             ->getMock();
 
         $plugin->expects($this->once())
             ->method('createMigrationHelper')
             ->willReturn($migrationHelper);
+
+        if ($mockAssetCopy) {
+            $plugin->expects($this->never())
+                ->method('copyDependencyBundleAssets');
+        }
+
         $plugin->setContainer($this->getContainer());
 
         return $plugin;

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -5,56 +5,19 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\Tests;
 
 use Nosto\NostoIntegration\NostoIntegration;
+use Nosto\NostoIntegration\Utils\MigrationHelper;
+use Nosto\Scheduler\NostoScheduler;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Migration\MigrationCollection;
-use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
 use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
-use Shopware\Core\Framework\Plugin\Util\AssetService;
-use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 class NostoIntegrationTest extends TestCase
 {
-    use IntegrationTestBehaviour;
-
-    protected function tearDown(): void
-    {
-        static::ensureKernelShutdown();
-
-        parent::tearDown();
-    }
-
-    public function testNostoSchedulerIsAddedOnActivation(): void
-    {
-        $this->mockDependencyMigrationExecution();
-
-        /** @var NostoIntegration $nostoIntegration */
-        $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
-
-        $assetService = $this->getMockBuilder(AssetService::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $assetService->expects($this->once())
-            ->method('copyAssetsFromBundle')
-            ->with('NostoScheduler');
-        $this->getContainer()->set('nosto.plugin.assetservice.public', $assetService);
-
-        $activateContext = $this->getMockBuilder(ActivateContext::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getContext'])
-            ->getMock();
-        $activateContext->method('getContext')->willReturn(Context::createDefaultContext());
-
-        $nostoIntegration->activate($activateContext);
-    }
-
     public function testNostoSchedulerMigrationsRunOnInstall(): void
     {
-        $this->mockDependencyMigrationExecution();
-
-        /** @var NostoIntegration $nostoIntegration */
-        $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
+        $plugin = $this->createPluginMock();
 
         $installContext = $this->getMockBuilder(InstallContext::class)
             ->disableOriginalConstructor()
@@ -62,15 +25,12 @@ class NostoIntegrationTest extends TestCase
             ->getMock();
         $installContext->method('getContext')->willReturn(Context::createDefaultContext());
 
-        $nostoIntegration->install($installContext);
+        $plugin->install($installContext);
     }
 
     public function testNostoSchedulerMigrationsRunOnUpdate(): void
     {
-        $this->mockDependencyMigrationExecution();
-
-        /** @var NostoIntegration $nostoIntegration */
-        $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
+        $plugin = $this->createPluginMock();
 
         $updateContext = $this->getMockBuilder(UpdateContext::class)
             ->disableOriginalConstructor()
@@ -79,28 +39,55 @@ class NostoIntegrationTest extends TestCase
         $updateContext->method('getContext')->willReturn(Context::createDefaultContext());
         $updateContext->method('getCurrentPluginVersion')->willReturn('5.2.9');
 
-        $nostoIntegration->update($updateContext);
+        $plugin->update($updateContext);
     }
 
-    private function mockDependencyMigrationExecution(): void
+    public function testNostoSchedulerIsAddedOnActivation(): void
+    {
+        $plugin = $this->createPluginMock();
+        $plugin->expects($this->once())
+            ->method('copyDependencyBundleAssets');
+
+        $activateContext = $this->getMockBuilder(ActivateContext::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getContext'])
+            ->getMock();
+        $activateContext->method('getContext')->willReturn(Context::createDefaultContext());
+
+        $plugin->activate($activateContext);
+    }
+
+    private function createPluginMock(): NostoIntegration
     {
         $migrationCollection = $this->getMockBuilder(MigrationCollection::class)
             ->disableOriginalConstructor()
             ->getMock();
         $migrationCollection->expects($this->once())
-            ->method('sync');
-        $migrationCollection->expects($this->once())
             ->method('migrateInPlace');
 
-        $migrationLoader = $this->getMockBuilder(MigrationCollectionLoader::class)
+        $migrationHelper = $this->getMockBuilder(MigrationHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $migrationLoader->expects($this->once())
-            ->method('addSource');
-        $migrationLoader->expects($this->once())
-            ->method('collect')
-            ->with('NostoScheduler')
+        $migrationHelper->expects($this->once())
+            ->method('getMigrationCollection')
+            ->with($this->isInstanceOf(NostoScheduler::class))
             ->willReturn($migrationCollection);
-        $this->getContainer()->set(MigrationCollectionLoader::class, $migrationLoader);
+
+        /** @var NostoIntegration&\PHPUnit\Framework\MockObject\MockObject $plugin */
+        $plugin = $this->getMockBuilder(NostoIntegration::class)
+            ->setConstructorArgs([
+                true,
+                'custom/plugins/nosto-shopware6',
+                $this->getContainer()->getParameter('kernel.project_dir'),
+            ])
+            ->onlyMethods(['createMigrationHelper', 'copyDependencyBundleAssets'])
+            ->getMock();
+
+        $plugin->expects($this->once())
+            ->method('createMigrationHelper')
+            ->willReturn($migrationHelper);
+        $plugin->setContainer($this->getContainer());
+
+        return $plugin;
     }
 }

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Nosto\NostoIntegration\Tests;
 
 use Nosto\NostoIntegration\NostoIntegration;
-use Nosto\NostoIntegration\Utils\MigrationHelper;
 use Nosto\Scheduler\NostoScheduler;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Migration\MigrationCollection;
+use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
 use Shopware\Core\Framework\Plugin\Util\AssetService;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -21,13 +22,22 @@ class NostoIntegrationTest extends TestCase
         /** @var NostoIntegration $nostoIntegration */
         $nostoIntegration = $this->getContainer()->get(NostoIntegration::class);
 
-        $migrationHelper = $this->getMockBuilder(MigrationHelper::class)
+        $migrationCollection = $this->getMockBuilder(MigrationCollection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $migrationHelper->expects($this->once())
-            ->method('getMigrationCollection')
-            ->with($this->isInstanceOf(NostoScheduler::class));
-        $this->getContainer()->set(MigrationHelper::class, $migrationHelper);
+        $migrationCollection->expects($this->once())
+            ->method('sync');
+
+        $migrationLoader = $this->getMockBuilder(MigrationCollectionLoader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $migrationLoader->expects($this->once())
+            ->method('addSource');
+        $migrationLoader->expects($this->once())
+            ->method('collect')
+            ->with('NostoScheduler')
+            ->willReturn($migrationCollection);
+        $this->getContainer()->set(MigrationCollectionLoader::class, $migrationLoader);
 
         $assetService = $this->getMockBuilder(AssetService::class)
             ->disableOriginalConstructor()

--- a/tests/NostoIntegrationTest.php
+++ b/tests/NostoIntegrationTest.php
@@ -87,7 +87,9 @@ class NostoIntegrationTest extends TestCase
                 'custom/plugins/nosto-shopware6',
                 $this->getContainer()->getParameter('kernel.project_dir'),
             ])
-            ->onlyMethods($mockAssetCopy ? ['createMigrationHelper', 'copyDependencyBundleAssets'] : ['createMigrationHelper'])
+            ->onlyMethods(
+                $mockAssetCopy ? ['createMigrationHelper', 'copyDependencyBundleAssets'] : ['createMigrationHelper'],
+            )
             ->getMock();
 
         $plugin->expects($this->once())


### PR DESCRIPTION
We have added a migration in job-scheduler dependency but it's not running automatically when updating the plugin. It only runs when the plugin is activating