### PR TITLE
NS-13557-avoidSerializingListingContext-v5

### DIFF
--- a/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -73,8 +73,6 @@ class ProductListingRoute extends AbstractProductListingRoute
             $request->server->all(),
             $request->getContent(),
         );
-        $originalContext = unserialize(serialize($context));
-        $originalCriteria = unserialize(serialize($criteria));
         try {
             $shouldHandleRequest = SearchHelper::shouldHandleRequest($context, $this->configProvider, true, $request);
 
@@ -84,6 +82,9 @@ class ProductListingRoute extends AbstractProductListingRoute
 
                 return $this->decorated->load($categoryId, $request, $context, $criteria);
             }
+
+            $originalContext = clone $context;
+            $originalCriteria = $criteria !== null ? clone $criteria : null;
 
             $criteria->addFilter(
                 new ProductAvailableFilter(

--- a/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
@@ -74,15 +74,16 @@ class ProductSearchRoute extends AbstractProductSearchRoute
             $request->server->all(),
             $request->getContent(),
         );
-        $originalContext = unserialize(serialize($context));
-        $originalCriteria = unserialize(serialize($criteria));
         $query = $request->query->get('search');
-        $originalCriteria->setTerm($query);
         try {
             if (!SearchHelper::shouldHandleRequest($context, $this->configProvider, false, $request)) {
                 $criteria->setTerm($query);
                 return $this->decorated->load($request, $context, $criteria);
             }
+
+            $originalContext = clone $context;
+            $originalCriteria = clone $criteria;
+            $originalCriteria->setTerm($query);
 
             if (!$request->get('search')) {
                 throw RoutingException::missingRequestParameter('search');


### PR DESCRIPTION
Replace serialize/unserialize with clone to avoid fatal errors when Shopware context or criteria objects contain non-serializable values such as closures.