### PR TITLE
NS-14095-fix not selected salechannel synced-v5

### DIFF
--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -235,6 +235,8 @@ class ProductHelper
             );
         }
 
+        $this->addSalesChannelVisibilityFilter($criteria, $salesChannelId);
+
         $criteria->addFilter(new EqualsAnyFilter('id', array_unique(array_values($existentParentProductIds))));
         $this->eventDispatcher->dispatch(new ProductLoadExistingParentCriteriaEvent($criteria, $context));
 
@@ -278,6 +280,8 @@ class ProductHelper
                 ),
             );
         }
+
+        $this->addSalesChannelVisibilityFilter($criteria, $salesChannelId);
 
         $this->eventDispatcher->dispatch(new ProductLoadExistingCriteriaEvent($criteria, $context));
 
@@ -395,6 +399,7 @@ class ProductHelper
         array $productIds,
         SalesChannelContext $context,
         bool $includeChildren = true,
+        bool $requireSalesChannelVisibility = false,
     ): EntityCollection {
         $shouldLog = $this->shouldLogExtra($context);
         $startedAt = $shouldLog ? microtime(true) : null;
@@ -424,6 +429,10 @@ class ProductHelper
             );
         }
 
+        if ($requireSalesChannelVisibility) {
+            $this->addSalesChannelVisibilityFilter($criteria, $context->getSalesChannelId());
+        }
+
         $result = $this->productRepository->search(
             $criteria,
             $context->getContext(),
@@ -441,6 +450,11 @@ class ProductHelper
         }
 
         return $result;
+    }
+
+    private function addSalesChannelVisibilityFilter(Criteria $criteria, string $salesChannelId): void
+    {
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
     }
 
     private function getSyncPartialCriteria(?string $title, SalesChannelContext $context): Criteria

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -235,7 +235,7 @@ class ProductHelper
             );
         }
 
-        $this->addSalesChannelVisibilityFilter($criteria, $salesChannelId);
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
 
         $criteria->addFilter(new EqualsAnyFilter('id', array_unique(array_values($existentParentProductIds))));
         $this->eventDispatcher->dispatch(new ProductLoadExistingParentCriteriaEvent($criteria, $context));
@@ -281,7 +281,7 @@ class ProductHelper
             );
         }
 
-        $this->addSalesChannelVisibilityFilter($criteria, $salesChannelId);
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
 
         $this->eventDispatcher->dispatch(new ProductLoadExistingCriteriaEvent($criteria, $context));
 
@@ -429,10 +429,11 @@ class ProductHelper
         }
 
         $salesChannelId = $context->getSalesChannelId();
-        $this->addSalesChannelVisibilityFilter($criteria, $salesChannelId);
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
 
         if ($includeChildren && $criteria->hasAssociation('children')) {
-            $this->addSalesChannelVisibilityFilter($criteria->getAssociation('children'), $salesChannelId);
+            $criteria->getAssociation('children')
+                ->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
         }
 
         $result = $this->productRepository->search(
@@ -452,11 +453,6 @@ class ProductHelper
         }
 
         return $result;
-    }
-
-    private function addSalesChannelVisibilityFilter(Criteria $criteria, string $salesChannelId): void
-    {
-        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
     }
 
     private function getSyncPartialCriteria(?string $title, SalesChannelContext $context): Criteria

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -399,7 +399,6 @@ class ProductHelper
         array $productIds,
         SalesChannelContext $context,
         bool $includeChildren = true,
-        bool $requireSalesChannelVisibility = false,
     ): EntityCollection {
         $shouldLog = $this->shouldLogExtra($context);
         $startedAt = $shouldLog ? microtime(true) : null;
@@ -429,8 +428,11 @@ class ProductHelper
             );
         }
 
-        if ($requireSalesChannelVisibility) {
-            $this->addSalesChannelVisibilityFilter($criteria, $context->getSalesChannelId());
+        $salesChannelId = $context->getSalesChannelId();
+        $this->addSalesChannelVisibilityFilter($criteria, $salesChannelId);
+
+        if ($includeChildren && $criteria->hasAssociation('children')) {
+            $this->addSalesChannelVisibilityFilter($criteria->getAssociation('children'), $salesChannelId);
         }
 
         $result = $this->productRepository->search(

--- a/src/Model/Operation/ProductSyncHandler.php
+++ b/src/Model/Operation/ProductSyncHandler.php
@@ -362,12 +362,7 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         $shopwareProductsFetchStartedAt = $shouldLogExtra ? microtime(true) : null;
         $allShopwareProducts = !empty($allUniqueIds)
             ? (PartialProductConverter::toPartialProductCollection(
-                $this->productHelper->getShopwareProductsPartial(
-                    array_keys($allUniqueIds),
-                    $context,
-                    true,
-                    true,
-                ),
+                $this->productHelper->getShopwareProductsPartial(array_keys($allUniqueIds), $context),
             ))
             : new PartialProductCollection();
         /** @var array<string, PartialProduct> $allShopwareProductsById */
@@ -612,12 +607,7 @@ class ProductSyncHandler implements Job\JobHandlerInterface
 
         $startedAt = $shouldLogExtra ? microtime(true) : null;
         $productsWithLoadedChildren = PartialProductConverter::toPartialProductCollection(
-            $this->productHelper->getShopwareProductsPartial(
-                array_keys($parentIdsNeedingChildren),
-                $context,
-                true,
-                true,
-            ),
+            $this->productHelper->getShopwareProductsPartial(array_keys($parentIdsNeedingChildren), $context),
         );
         $productsWithLoadedChildrenById = [];
         /** @var PartialProduct $productWithLoadedChildren */

--- a/src/Model/Operation/ProductSyncHandler.php
+++ b/src/Model/Operation/ProductSyncHandler.php
@@ -362,7 +362,12 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         $shopwareProductsFetchStartedAt = $shouldLogExtra ? microtime(true) : null;
         $allShopwareProducts = !empty($allUniqueIds)
             ? (PartialProductConverter::toPartialProductCollection(
-                $this->productHelper->getShopwareProductsPartial(array_keys($allUniqueIds), $context),
+                $this->productHelper->getShopwareProductsPartial(
+                    array_keys($allUniqueIds),
+                    $context,
+                    true,
+                    true,
+                ),
             ))
             : new PartialProductCollection();
         /** @var array<string, PartialProduct> $allShopwareProductsById */
@@ -610,6 +615,7 @@ class ProductSyncHandler implements Job\JobHandlerInterface
             $this->productHelper->getShopwareProductsPartial(
                 array_keys($parentIdsNeedingChildren),
                 $context,
+                true,
                 true,
             ),
         );

--- a/src/Twig/Extension/NostoExtension.php
+++ b/src/Twig/Extension/NostoExtension.php
@@ -177,9 +177,6 @@ class NostoExtension extends AbstractExtension
         if ($mainProduct instanceof PartialEntity && !$mainProduct instanceof PartialProduct) {
             $mainProduct = PartialProductConverter::toPartialProduct($mainProduct);
         }
-        if (!$mainProduct instanceof PartialProduct) {
-            return '';
-        }
 
         /** @var PartialProduct $variantFromDb */
         $criteria = NostoCriteriaFactory::createWithIds([$variantId]);

--- a/src/Twig/Extension/NostoExtension.php
+++ b/src/Twig/Extension/NostoExtension.php
@@ -144,9 +144,11 @@ class NostoExtension extends AbstractExtension
     ): string|NostoProduct {
         $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('id', $id));
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $context->getSalesChannelId()));
         $criteria->addFields(ProductFieldSets::productFieldsWithChildren());
 
         $childrenCriteria = $criteria->getAssociation('children');
+        $childrenCriteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $context->getSalesChannelId()));
 
         if (!$this->configProvider->isEnabledSyncInactiveProducts(
             $context->getSalesChannelId(),
@@ -175,9 +177,13 @@ class NostoExtension extends AbstractExtension
         if ($mainProduct instanceof PartialEntity && !$mainProduct instanceof PartialProduct) {
             $mainProduct = PartialProductConverter::toPartialProduct($mainProduct);
         }
+        if (!$mainProduct instanceof PartialProduct) {
+            return '';
+        }
 
         /** @var PartialProduct $variantFromDb */
         $criteria = NostoCriteriaFactory::createWithIds([$variantId]);
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $context->getSalesChannelId()));
         $criteria->addFields(ProductFieldSets::productFields());
 
         $variantFromDb = $this->productRepository

--- a/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
+++ b/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Aggreg
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
@@ -68,6 +69,11 @@ final class ProductHelperTest extends TestCase
 
         self::assertInstanceOf(Criteria::class, $capturedCriteria);
         self::assertTrue($capturedCriteria->hasEqualsFilter('active'));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
         self::assertContainsOnlyInstancesOf(NotFilter::class, array_filter(
             $capturedCriteria->getFilters(),
             static fn ($filter): bool => $filter instanceof NotFilter,
@@ -113,6 +119,11 @@ final class ProductHelperTest extends TestCase
 
         self::assertInstanceOf(Criteria::class, $capturedCriteria);
         self::assertFalse($capturedCriteria->hasEqualsFilter('active'));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     public function testGetShopwareProductsPartialAddsChildrenFiltersWhenInactiveSyncIsDisabled(): void
@@ -239,6 +250,46 @@ final class ProductHelperTest extends TestCase
         $helper->getShopwareProductsPartial(['product-id-1'], $this->createContext());
     }
 
+    public function testGetShopwareProductsPartialCanRequireSalesChannelVisibility(): void
+    {
+        $configProvider = $this->createMock(ConfigProvider::class);
+        $configProvider->method('isEnabledSyncInactiveProducts')->willReturn(true);
+        $configProvider->method('getCategoryBlocklist')->willReturn([]);
+
+        $productRepository = $this->createMock(EntityRepository::class);
+        $productRepository->method('getDefinition')->willReturn($this->createDefinition('product_test'));
+
+        $capturedCriteria = null;
+        $productRepository->method('search')->willReturnCallback(
+            static function (Criteria $criteria, Context $context) use (&$capturedCriteria): EntitySearchResult {
+                $capturedCriteria = $criteria;
+
+                return new EntitySearchResult(
+                    ProductEntity::class,
+                    0,
+                    new EntityCollection(),
+                    new AggregationResultCollection(),
+                    $criteria,
+                    $context,
+                );
+            },
+        );
+
+        $helper = $this->createHelper(
+            productRepository: $productRepository,
+            configProvider: $configProvider,
+        );
+
+        $helper->getShopwareProductsPartial(['product-id-1'], $this->createContext(), true, true);
+
+        self::assertInstanceOf(Criteria::class, $capturedCriteria);
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
+    }
+
     public function testGetShopwareProductsPartialSkipsChildrenAssociationFiltersWhenIncludeChildrenIsFalse(): void
     {
         $configProvider = $this->createMock(ConfigProvider::class);
@@ -316,6 +367,17 @@ final class ProductHelperTest extends TestCase
         $context->method('getContext')->willReturn(Context::createDefaultContext());
 
         return $context;
+    }
+
+    private function criteriaHasEqualsFilter(Criteria $criteria, string $field, mixed $value): bool
+    {
+        foreach ($criteria->getFilters() as $filter) {
+            if ($filter instanceof EqualsFilter && $filter->getField() === $field && $filter->getValue() === $value) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function createDefinition(string $entityName): EntityDefinition

--- a/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
+++ b/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
@@ -124,12 +124,6 @@ final class ProductHelperTest extends TestCase
             'visibilities.salesChannelId',
             'sales-channel-id',
         ));
-        $childrenCriteria = $capturedCriteria->getAssociation('children');
-        self::assertTrue($this->criteriaHasEqualsFilter(
-            $childrenCriteria,
-            'visibilities.salesChannelId',
-            'sales-channel-id',
-        ));
     }
 
     public function testGetShopwareProductsPartialAddsChildrenFiltersWhenInactiveSyncIsDisabled(): void

--- a/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
+++ b/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
@@ -124,6 +124,12 @@ final class ProductHelperTest extends TestCase
             'visibilities.salesChannelId',
             'sales-channel-id',
         ));
+        $childrenCriteria = $capturedCriteria->getAssociation('children');
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $childrenCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     public function testGetShopwareProductsPartialAddsChildrenFiltersWhenInactiveSyncIsDisabled(): void
@@ -171,6 +177,16 @@ final class ProductHelperTest extends TestCase
             $childrenCriteria->getFilters(),
             static fn ($filter): bool => $filter instanceof NotFilter,
         ));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $childrenCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     public function testGetShopwareProductsPartialDoesNotAddChildrenInactiveFilterWhenInactiveSyncIsEnabled(): void
@@ -209,6 +225,16 @@ final class ProductHelperTest extends TestCase
         self::assertFalse($capturedCriteria->hasEqualsFilter('active'));
         $childrenCriteria = $capturedCriteria->getAssociation('children');
         self::assertFalse($childrenCriteria->hasEqualsFilter('active'));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $childrenCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     public function testGetShopwareProductsPartialUsesBaseProductRepositoryInsteadOfSalesChannelRepository(): void
@@ -280,7 +306,7 @@ final class ProductHelperTest extends TestCase
             configProvider: $configProvider,
         );
 
-        $helper->getShopwareProductsPartial(['product-id-1'], $this->createContext(), true, true);
+        $helper->getShopwareProductsPartial(['product-id-1'], $this->createContext());
 
         self::assertInstanceOf(Criteria::class, $capturedCriteria);
         self::assertTrue($this->criteriaHasEqualsFilter(
@@ -329,6 +355,11 @@ final class ProductHelperTest extends TestCase
             static fn ($filter): bool => $filter instanceof NotFilter,
         ));
         self::assertFalse($capturedCriteria->hasAssociation('children'));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     private function createHelper(


### PR DESCRIPTION
Fix sales-channel visibility filtering in Nosto product sync  (When a product is not assigned to a sales channel it wont synced to Nosto)
