### PR TITLE
NS-14110-NS-14095-NS-13557-develop

### DIFF
--- a/.github/action/setup_runner/action.yml
+++ b/.github/action/setup_runner/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup PHP with Composer 2
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ inputs.php-version }}"
+        php-version: ${{ inputs.php-version }}
         extensions: dom, gd, mbstring, pdo_mysql, zip
         coverage: xdebug
         tools: composer:v2

--- a/.github/action/setup_shop/action.yml
+++ b/.github/action/setup_shop/action.yml
@@ -12,6 +12,13 @@ runs:
       shell: bash
       run: shopware-cli project create shopware ${{ inputs.shopware-version }} || true
 
+    - name: Clear Composer GitHub auth
+      shell: bash
+      run: |
+        echo 'COMPOSER_AUTH={}' >> "$GITHUB_ENV"
+        composer config -g --unset github-oauth.github.com || true
+        composer config -g --unset --auth github-oauth.github.com || true
+
     - name: Configure Composer to bypass audit and update
       shell: bash
       run: |

--- a/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -73,8 +73,6 @@ class ProductListingRoute extends AbstractProductListingRoute
             $request->server->all(),
             $request->getContent(),
         );
-        $originalContext = unserialize(serialize($context));
-        $originalCriteria = unserialize(serialize($criteria));
         try {
             $shouldHandleRequest = SearchHelper::shouldHandleRequest($context, $this->configProvider, true, $request);
 
@@ -84,6 +82,9 @@ class ProductListingRoute extends AbstractProductListingRoute
 
                 return $this->decorated->load($categoryId, $request, $context, $criteria);
             }
+
+            $originalContext = clone $context;
+            $originalCriteria = $criteria !== null ? clone $criteria : null;
 
             $criteria->addFilter(
                 new ProductAvailableFilter(

--- a/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
+++ b/src/Decorator/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
@@ -74,15 +74,16 @@ class ProductSearchRoute extends AbstractProductSearchRoute
             $request->server->all(),
             $request->getContent(),
         );
-        $originalContext = unserialize(serialize($context));
-        $originalCriteria = unserialize(serialize($criteria));
         $query = $request->query->get('search');
-        $originalCriteria->setTerm($query);
         try {
             if (!SearchHelper::shouldHandleRequest($context, $this->configProvider, false, $request)) {
                 $criteria->setTerm($query);
                 return $this->decorated->load($request, $context, $criteria);
             }
+
+            $originalContext = clone $context;
+            $originalCriteria = clone $criteria;
+            $originalCriteria->setTerm($query);
 
             if (!$request->get('search')) {
                 throw RoutingException::missingRequestParameter('search');

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -19,6 +19,7 @@ use Nosto\NostoIntegration\Struct\FiltersExtension;
 use Nosto\NostoIntegration\Struct\IdToFieldMapping;
 use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\Detail\AbstractProductDetailRoute;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
@@ -45,6 +46,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class ProductHelper
 {
+    /**
+     * @var array<string, CalculatedPrice|null>
+     */
+    private array $calculatedPriceCache = [];
+
     public function __construct(
         private readonly EntityRepository $productRepository,
         private readonly AbstractProductDetailRoute $productRoute,
@@ -158,6 +164,34 @@ class ProductHelper
         $shopwareProduct = $this->getShopwareProducts([$productId], $context, true);
 
         return $shopwareProduct->get($productId) ?? null;
+    }
+
+    public function getSalesChannelCalculatedPrice(string $productId, SalesChannelContext $context): ?CalculatedPrice
+    {
+        $cacheKey = implode('|', [
+            $context->getSalesChannelId(),
+            $context->getLanguageId(),
+            $context->getCurrencyId(),
+            $productId,
+        ]);
+
+        if (array_key_exists($cacheKey, $this->calculatedPriceCache)) {
+            return $this->calculatedPriceCache[$cacheKey];
+        }
+
+        $criteria = NostoCriteriaFactory::createWithIds(
+            [$productId],
+            'product_sync.productHelper.getSalesChannelCalculatedPrice',
+        );
+
+        $product = $this->salesChannelProductRepository->search($criteria, $context)->get($productId);
+        if (!$product instanceof SalesChannelProductEntity) {
+            return $this->calculatedPriceCache[$cacheKey] = null;
+        }
+
+        $price = $product->getCalculatedPrices()->first() ?: $product->getCalculatedPrice();
+
+        return $this->calculatedPriceCache[$cacheKey] = $price instanceof CalculatedPrice ? $price : null;
     }
 
     private function getCommonCriteria(?string $title = null): Criteria

--- a/src/Model/Nosto/Entity/Helper/ProductHelper.php
+++ b/src/Model/Nosto/Entity/Helper/ProductHelper.php
@@ -269,6 +269,8 @@ class ProductHelper
             );
         }
 
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
+
         $criteria->addFilter(new EqualsAnyFilter('id', array_unique(array_values($existentParentProductIds))));
         $this->eventDispatcher->dispatch(new ProductLoadExistingParentCriteriaEvent($criteria, $context));
 
@@ -312,6 +314,8 @@ class ProductHelper
                 ),
             );
         }
+
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
 
         $this->eventDispatcher->dispatch(new ProductLoadExistingCriteriaEvent($criteria, $context));
 
@@ -456,6 +460,14 @@ class ProductHelper
                     [new EqualsAnyFilter('categoriesRo.id', $categoryBlocklist)],
                 ),
             );
+        }
+
+        $salesChannelId = $context->getSalesChannelId();
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
+
+        if ($includeChildren && $criteria->hasAssociation('children')) {
+            $criteria->getAssociation('children')
+                ->addFilter(new EqualsFilter('visibilities.salesChannelId', $salesChannelId));
         }
 
         $result = $this->productRepository->search(

--- a/src/Model/Nosto/Entity/Product/PartialBuilder.php
+++ b/src/Model/Nosto/Entity/Product/PartialBuilder.php
@@ -407,47 +407,24 @@ class PartialBuilder
         object $product,
         SalesChannelContext $context,
     ): void {
+        if (!$this->configProvider->isEnabledMultiCurrency($context->getSalesChannelId(), $context->getLanguageId())) {
+            $productId = $product->getId();
+            $productPrice = $productId ? $this->productHelper->getSalesChannelCalculatedPrice(
+                $productId,
+                $context,
+            ) : null;
+            if ($productPrice instanceof CalculatedPrice) {
+                $this->setCalculatedPrice($nostoProdcut, $productPrice, $context);
+                return;
+            }
+        }
+
         $calculatedPrices = $product->getCalculatedPrices();
         $productPrice = $calculatedPrices instanceof Collection
             ? ($calculatedPrices->first() ?: $product->getCalculatedPrice())
             : $product->getCalculatedPrice();
         if ($productPrice instanceof CalculatedPrice) {
-            $listPrice = $productPrice->getListPrice() ?
-                $productPrice->getListPrice()->getPrice() :
-                $productPrice->getUnitPrice();
-
-            $unitPrice = $productPrice->getUnitPrice();
-            $isGross = empty($context->getCurrentCustomerGroup()) || $context->getCurrentCustomerGroup()->getDisplayGross();
-
-            if (!$isGross) {
-                $price = $this->calculator->calculate(
-                    new QuantityPriceDefinition($unitPrice, $productPrice->getTaxRules(), 1),
-                    $context->getItemRounding(),
-                );
-
-                $priceList = $this->calculator->calculate(
-                    new QuantityPriceDefinition($listPrice, $productPrice->getTaxRules(), 1),
-                    $context->getItemRounding(),
-                );
-                if (!empty($price->getCalculatedTaxes()->getElements())) {
-                    $unitPrice = 0;
-
-                    foreach ($price->getCalculatedTaxes()->getElements() as $tax) {
-                        $unitPrice += ($tax->getTax() + $tax->getPrice());
-                    }
-                }
-
-                if (!empty($priceList->getCalculatedTaxes()->getElements())) {
-                    $listPrice = 0;
-
-                    foreach ($priceList->getCalculatedTaxes()->getElements() as $tax) {
-                        $listPrice += ($tax->getTax() + $tax->getPrice());
-                    }
-                }
-            }
-
-            $nostoProdcut->setPrice($this->priceRounding->cashRound($unitPrice, $context->getItemRounding()));
-            $nostoProdcut->setListPrice($this->priceRounding->cashRound($listPrice, $context->getItemRounding()));
+            $this->setCalculatedPrice($nostoProdcut, $productPrice, $context);
             return;
         }
 
@@ -463,6 +440,49 @@ class PartialBuilder
                 $this->priceRounding->cashRound($price->getListPrice()->getGross(), $context->getItemRounding()),
             );
         }
+    }
+
+    private function setCalculatedPrice(
+        NostoProduct $nostoProdcut,
+        CalculatedPrice $productPrice,
+        SalesChannelContext $context,
+    ): void {
+        $listPrice = $productPrice->getListPrice() ?
+            $productPrice->getListPrice()->getPrice() :
+            $productPrice->getUnitPrice();
+
+        $unitPrice = $productPrice->getUnitPrice();
+        $isGross = empty($context->getCurrentCustomerGroup()) || $context->getCurrentCustomerGroup()->getDisplayGross();
+
+        if (!$isGross) {
+            $price = $this->calculator->calculate(
+                new QuantityPriceDefinition($unitPrice, $productPrice->getTaxRules(), 1),
+                $context->getItemRounding(),
+            );
+
+            $priceList = $this->calculator->calculate(
+                new QuantityPriceDefinition($listPrice, $productPrice->getTaxRules(), 1),
+                $context->getItemRounding(),
+            );
+            if (!empty($price->getCalculatedTaxes()->getElements())) {
+                $unitPrice = 0;
+
+                foreach ($price->getCalculatedTaxes()->getElements() as $tax) {
+                    $unitPrice += ($tax->getTax() + $tax->getPrice());
+                }
+            }
+
+            if (!empty($priceList->getCalculatedTaxes()->getElements())) {
+                $listPrice = 0;
+
+                foreach ($priceList->getCalculatedTaxes()->getElements() as $tax) {
+                    $listPrice += ($tax->getTax() + $tax->getPrice());
+                }
+            }
+        }
+
+        $nostoProdcut->setPrice($this->priceRounding->cashRound($unitPrice, $context->getItemRounding()));
+        $nostoProdcut->setListPrice($this->priceRounding->cashRound($listPrice, $context->getItemRounding()));
     }
 
     private function initTags(

--- a/src/Model/Nosto/Entity/Product/SkuBuilder.php
+++ b/src/Model/Nosto/Entity/Product/SkuBuilder.php
@@ -13,6 +13,10 @@ use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\CrossSelling\CrossSellingBuilder;
 use Nosto\NostoIntegration\Utils\NostoCriteriaFactory;
 use Nosto\Types\Product\ProductInterface;
+use Shopware\Core\Checkout\Cart\Price\CashRounding;
+use Shopware\Core\Checkout\Cart\Price\NetPriceCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
@@ -30,6 +34,8 @@ class SkuBuilder
     public function __construct(
         private readonly ConfigProvider $configProvider,
         private readonly ProductHelper $productHelper,
+        private readonly NetPriceCalculator $calculator,
+        private readonly CashRounding $priceRounding,
         private readonly CrossSellingBuilder $crossSellingBuilder,
         private readonly EntityRepository $propertyGroupOptionRepository,
     ) {
@@ -120,14 +126,7 @@ class SkuBuilder
             $nostoSku->setImageUrl($placeholderImageUrl);
         }
 
-        $price = $product->getCurrencyPrice($context->getCurrencyId());
-        if ($price !== null) {
-            $nostoSku->setPrice($price->getGross());
-
-            if ($price->getListPrice() !== null) {
-                $nostoSku->setListPrice($price->getListPrice()->getGross());
-            }
-        }
+        $this->setPrices($nostoSku, $product, $context);
 
         if ($this->configProvider->isEnabledInventoryLevels($channelId, $languageId)) {
             $nostoSku->setInventoryLevel($stock);
@@ -233,6 +232,78 @@ class SkuBuilder
         }
 
         return $nostoSku;
+    }
+
+    private function setPrices(
+        NostoSku $nostoSku,
+        ProductEntity|PartialEntity|PartialProduct $product,
+        SalesChannelContext $context,
+    ): void {
+        if (!$this->configProvider->isEnabledMultiCurrency($context->getSalesChannelId(), $context->getLanguageId())) {
+            $productId = $product->getId();
+            $productPrice = $productId ? $this->productHelper->getSalesChannelCalculatedPrice(
+                $productId,
+                $context,
+            ) : null;
+            if ($productPrice instanceof CalculatedPrice) {
+                $this->setCalculatedPrice($nostoSku, $productPrice, $context);
+                return;
+            }
+        }
+
+        $price = $product->getCurrencyPrice($context->getCurrencyId());
+        if ($price === null) {
+            return;
+        }
+
+        $nostoSku->setPrice($price->getGross());
+
+        if ($price->getListPrice() !== null) {
+            $nostoSku->setListPrice($price->getListPrice()->getGross());
+        }
+    }
+
+    private function setCalculatedPrice(
+        NostoSku $nostoSku,
+        CalculatedPrice $productPrice,
+        SalesChannelContext $context,
+    ): void {
+        $listPrice = $productPrice->getListPrice() ?
+            $productPrice->getListPrice()->getPrice() :
+            $productPrice->getUnitPrice();
+
+        $unitPrice = $productPrice->getUnitPrice();
+        $isGross = empty($context->getCurrentCustomerGroup()) || $context->getCurrentCustomerGroup()->getDisplayGross();
+
+        if (!$isGross) {
+            $price = $this->calculator->calculate(
+                new QuantityPriceDefinition($unitPrice, $productPrice->getTaxRules(), 1),
+                $context->getItemRounding(),
+            );
+
+            $priceList = $this->calculator->calculate(
+                new QuantityPriceDefinition($listPrice, $productPrice->getTaxRules(), 1),
+                $context->getItemRounding(),
+            );
+            if (!empty($price->getCalculatedTaxes()->getElements())) {
+                $unitPrice = 0;
+
+                foreach ($price->getCalculatedTaxes()->getElements() as $tax) {
+                    $unitPrice += ($tax->getTax() + $tax->getPrice());
+                }
+            }
+
+            if (!empty($priceList->getCalculatedTaxes()->getElements())) {
+                $listPrice = 0;
+
+                foreach ($priceList->getCalculatedTaxes()->getElements() as $tax) {
+                    $listPrice += ($tax->getTax() + $tax->getPrice());
+                }
+            }
+        }
+
+        $nostoSku->setPrice($this->priceRounding->cashRound($unitPrice, $context->getItemRounding()));
+        $nostoSku->setListPrice($this->priceRounding->cashRound($listPrice, $context->getItemRounding()));
     }
 
     private function getValue(object $entity, string $field): mixed

--- a/src/Model/Operation/ProductSyncHandler.php
+++ b/src/Model/Operation/ProductSyncHandler.php
@@ -31,10 +31,14 @@ use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Rule\RuleEntity;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -49,6 +53,7 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         private readonly AbstractSalesChannelContextFactory $channelContextFactory,
         private readonly PartialProvider $partialProductProvider,
         private readonly Account\Provider $accountProvider,
+        private readonly EntityRepository $domainRepository,
         private readonly ConfigProvider $configProvider,
         private readonly AbstractRuleLoader $ruleLoader,
         private readonly ProductHelper $productHelper,
@@ -75,13 +80,7 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         $accounts = $this->resolveAccounts($message);
 
         foreach ($accounts as $account) {
-            $channelContext = $this->channelContextFactory->create(
-                Uuid::randomHex(),
-                $account->getChannelId(),
-                [
-                    SalesChannelContextService::LANGUAGE_ID => $account->getLanguageId(),
-                ],
-            );
+            $channelContext = $this->createAccountContext($account, $message->getContext());
             $channelContext->setRuleIds($this->loadRuleIds($channelContext));
 
             if ($shouldLogExtra === null) {
@@ -125,6 +124,46 @@ class ProductSyncHandler implements Job\JobHandlerInterface
         }
 
         return $this->accountProvider->all($context);
+    }
+
+    protected function createAccountContext(Account $account, Context $context): SalesChannelContext
+    {
+        $channelId = $account->getChannelId();
+        $languageId = $account->getLanguageId();
+
+        $parameters = [
+            SalesChannelContextService::LANGUAGE_ID => $languageId,
+        ];
+
+        if (!$this->configProvider->isEnabledMultiCurrency($channelId, $languageId)) {
+            $domainId = $this->configProvider->getDomainId($channelId, $languageId);
+            if ($domainId !== null && Uuid::isValid($domainId)) {
+                $parameters[SalesChannelContextService::DOMAIN_ID] = $domainId;
+            }
+
+            $currencyId = $this->getDomainCurrencyId($channelId, $languageId, $context);
+            if ($currencyId !== null && Uuid::isValid($currencyId)) {
+                $parameters[SalesChannelContextService::CURRENCY_ID] = $currencyId;
+            }
+        }
+
+        return $this->channelContextFactory->create(
+            Uuid::randomHex(),
+            $channelId,
+            $parameters,
+        );
+    }
+
+    protected function getDomainCurrencyId(?string $channelId, ?string $languageId, Context $context): ?string
+    {
+        $domainId = $this->configProvider->getDomainId($channelId, $languageId);
+        if ($domainId === null || !Uuid::isValid($domainId)) {
+            return null;
+        }
+
+        $domain = $this->domainRepository->search(new Criteria([$domainId]), $context)->first();
+
+        return $domain instanceof SalesChannelDomainEntity ? $domain->getCurrencyId() : null;
     }
 
     /**

--- a/src/Model/Operation/ProductSyncHandler.php
+++ b/src/Model/Operation/ProductSyncHandler.php
@@ -646,11 +646,7 @@ class ProductSyncHandler implements Job\JobHandlerInterface
 
         $startedAt = $shouldLogExtra ? microtime(true) : null;
         $productsWithLoadedChildren = PartialProductConverter::toPartialProductCollection(
-            $this->productHelper->getShopwareProductsPartial(
-                array_keys($parentIdsNeedingChildren),
-                $context,
-                true,
-            ),
+            $this->productHelper->getShopwareProductsPartial(array_keys($parentIdsNeedingChildren), $context),
         );
         $productsWithLoadedChildrenById = [];
         /** @var PartialProduct $productWithLoadedChildren */

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -34,6 +34,7 @@
                       id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
             <argument key="$partialProductProvider" type="service"
                       id="Nosto\NostoIntegration\Model\Nosto\Entity\Product\PartialProvider"/>
+            <argument key="$domainRepository" type="service" id="sales_channel_domain.repository"/>
             <argument key="$ruleLoader" type="service" id="Shopware\Core\Checkout\Cart\RuleLoader"/>
             <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
         </service>
@@ -401,6 +402,7 @@
                       id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
             <argument key="$partialProductProvider" type="service"
                       id="Nosto\NostoIntegration\Model\Nosto\Entity\Product\PartialProvider"/>
+            <argument key="$domainRepository" type="service" id="sales_channel_domain.repository"/>
             <argument key="$ruleLoader" type="service" id="Shopware\Core\Checkout\Cart\RuleLoader"/>
             <argument key="$logger" type="service" id="monolog.logger.nosto_integration"/>
         </service>

--- a/src/Service/NostoMonitoringProductDebug.php
+++ b/src/Service/NostoMonitoringProductDebug.php
@@ -19,10 +19,9 @@ use Nosto\Scheduler\Model\Job;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
-use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -35,6 +34,7 @@ class NostoMonitoringProductDebug extends ProductSyncHandler
         private readonly AbstractSalesChannelContextFactory $channelContextFactory,
         private readonly PartialProvider $partialProductProvider,
         private readonly Account\Provider $accountProvider,
+        private readonly EntityRepository $domainRepository,
         private readonly ConfigProvider $configProvider,
         private readonly AbstractRuleLoader $ruleLoader,
         private readonly ProductHelper $productHelper,
@@ -46,6 +46,7 @@ class NostoMonitoringProductDebug extends ProductSyncHandler
             $this->channelContextFactory,
             $this->partialProductProvider,
             $this->accountProvider,
+            $this->domainRepository,
             $this->configProvider,
             $this->ruleLoader,
             $this->productHelper,
@@ -58,14 +59,7 @@ class NostoMonitoringProductDebug extends ProductSyncHandler
     public function execute(object $message): Job\JobResult
     {
         foreach ($this->accountProvider->all($message->getContext()) as $account) {
-            $channelContext = $this->channelContextFactory->create(
-                Uuid::randomHex(),
-                $account->getChannelId(),
-                [
-                    SalesChannelContextService::LANGUAGE_ID => $account->getLanguageId(),
-                ],
-            );
-
+            $channelContext = $this->createAccountContext($account, $message->getContext());
             $channelContext->setRuleIds($this->loadRuleIds($channelContext));
 
             $this->doOperation($account, $channelContext, $message->getProductIds());

--- a/src/Twig/Extension/NostoExtension.php
+++ b/src/Twig/Extension/NostoExtension.php
@@ -144,9 +144,11 @@ class NostoExtension extends AbstractExtension
     ): string|NostoProduct {
         $criteria = NostoCriteriaFactory::create();
         $criteria->addFilter(new EqualsFilter('id', $id));
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $context->getSalesChannelId()));
         $criteria->addFields(ProductFieldSets::productFieldsWithChildren());
 
         $childrenCriteria = $criteria->getAssociation('children');
+        $childrenCriteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $context->getSalesChannelId()));
 
         if (!$this->configProvider->isEnabledSyncInactiveProducts(
             $context->getSalesChannelId(),
@@ -178,6 +180,7 @@ class NostoExtension extends AbstractExtension
 
         /** @var PartialProduct $variantFromDb */
         $criteria = NostoCriteriaFactory::createWithIds([$variantId]);
+        $criteria->addFilter(new EqualsFilter('visibilities.salesChannelId', $context->getSalesChannelId()));
         $criteria->addFields(ProductFieldSets::productFields());
 
         $variantFromDb = $this->productRepository

--- a/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
+++ b/tests/Unit/Model/Nosto/Entity/Helper/ProductHelperTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Aggreg
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
@@ -68,6 +69,11 @@ final class ProductHelperTest extends TestCase
 
         self::assertInstanceOf(Criteria::class, $capturedCriteria);
         self::assertTrue($capturedCriteria->hasEqualsFilter('active'));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
         self::assertContainsOnlyInstancesOf(NotFilter::class, array_filter(
             $capturedCriteria->getFilters(),
             static fn ($filter): bool => $filter instanceof NotFilter,
@@ -124,6 +130,47 @@ final class ProductHelperTest extends TestCase
         ));
     }
 
+    public function testGetProductsIteratorDoesNotApplyInactiveFilterWhenInactiveSyncIsEnabled(): void
+    {
+        $configProvider = $this->createMock(ConfigProvider::class);
+        $configProvider->method('isEnabledSyncInactiveProducts')->willReturn(true);
+        $configProvider->method('getCategoryBlocklist')->willReturn([]);
+
+        $productRepository = $this->createMock(EntityRepository::class);
+        $productRepository->method('getDefinition')->willReturn($this->createDefinition('product_test'));
+
+        $capturedCriteria = null;
+        $productRepository->method('search')->willReturnCallback(
+            static function (Criteria $criteria, Context $context) use (&$capturedCriteria): EntitySearchResult {
+                $capturedCriteria = $criteria;
+
+                return new EntitySearchResult(
+                    ProductEntity::class,
+                    0,
+                    new EntityCollection(),
+                    new AggregationResultCollection(),
+                    $criteria,
+                    $context,
+                );
+            },
+        );
+
+        $helper = $this->createHelper(
+            productRepository: $productRepository,
+            configProvider: $configProvider,
+        );
+
+        $helper->getProductsIterator(['product-id-1'], $this->createContext())->fetch();
+
+        self::assertInstanceOf(Criteria::class, $capturedCriteria);
+        self::assertFalse($capturedCriteria->hasEqualsFilter('active'));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
+    }
+
     public function testGetShopwareProductsPartialAddsChildrenFiltersWhenInactiveSyncIsDisabled(): void
     {
         $configProvider = $this->createMock(ConfigProvider::class);
@@ -169,6 +216,16 @@ final class ProductHelperTest extends TestCase
             $childrenCriteria->getFilters(),
             static fn ($filter): bool => $filter instanceof NotFilter,
         ));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $childrenCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     public function testGetShopwareProductsPartialOmitsChildrenActiveFilterWhenInactiveSyncIsEnabled(): void
@@ -212,6 +269,16 @@ final class ProductHelperTest extends TestCase
             $childrenCriteria->getFilters(),
             static fn ($filter): bool => $filter instanceof NotFilter,
         ));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $childrenCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     public function testGetShopwareProductsPartialUsesBaseProductRepositoryInsteadOfSalesChannelRepository(): void
@@ -253,6 +320,46 @@ final class ProductHelperTest extends TestCase
         $helper->getShopwareProductsPartial(['product-id-1'], $this->createContext());
     }
 
+    public function testGetShopwareProductsPartialCanRequireSalesChannelVisibility(): void
+    {
+        $configProvider = $this->createMock(ConfigProvider::class);
+        $configProvider->method('isEnabledSyncInactiveProducts')->willReturn(true);
+        $configProvider->method('getCategoryBlocklist')->willReturn([]);
+
+        $productRepository = $this->createMock(EntityRepository::class);
+        $productRepository->method('getDefinition')->willReturn($this->createDefinition('product_test'));
+
+        $capturedCriteria = null;
+        $productRepository->method('search')->willReturnCallback(
+            static function (Criteria $criteria, Context $context) use (&$capturedCriteria): EntitySearchResult {
+                $capturedCriteria = $criteria;
+
+                return new EntitySearchResult(
+                    ProductEntity::class,
+                    0,
+                    new EntityCollection(),
+                    new AggregationResultCollection(),
+                    $criteria,
+                    $context,
+                );
+            },
+        );
+
+        $helper = $this->createHelper(
+            productRepository: $productRepository,
+            configProvider: $configProvider,
+        );
+
+        $helper->getShopwareProductsPartial(['product-id-1'], $this->createContext());
+
+        self::assertInstanceOf(Criteria::class, $capturedCriteria);
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
+    }
+
     public function testGetShopwareProductsPartialSkipsChildrenAssociationFiltersWhenIncludeChildrenIsFalse(): void
     {
         $configProvider = $this->createMock(ConfigProvider::class);
@@ -292,6 +399,11 @@ final class ProductHelperTest extends TestCase
             static fn ($filter): bool => $filter instanceof NotFilter,
         ));
         self::assertFalse($capturedCriteria->hasAssociation('children'));
+        self::assertTrue($this->criteriaHasEqualsFilter(
+            $capturedCriteria,
+            'visibilities.salesChannelId',
+            'sales-channel-id',
+        ));
     }
 
     private function createHelper(
@@ -330,6 +442,17 @@ final class ProductHelperTest extends TestCase
         $context->method('getContext')->willReturn(Context::createDefaultContext());
 
         return $context;
+    }
+
+    private function criteriaHasEqualsFilter(Criteria $criteria, string $field, mixed $value): bool
+    {
+        foreach ($criteria->getFilters() as $filter) {
+            if ($filter instanceof EqualsFilter && $filter->getField() === $field && $filter->getValue() === $value) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function createDefinition(string $entityName): EntityDefinition

--- a/tests/Unit/Model/Nosto/Entity/Product/SkuBuilderTest.php
+++ b/tests/Unit/Model/Nosto/Entity/Product/SkuBuilderTest.php
@@ -13,7 +13,14 @@ use Nosto\NostoIntegration\Model\Nosto\Entity\Product\PartialProduct;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\PartialProductConverter;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\SkuBuilder;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Price\CashRounding;
+use Shopware\Core\Checkout\Cart\Price\NetPriceCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\ListPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -56,6 +63,8 @@ final class SkuBuilderTest extends TestCase
         $builder = new SkuBuilder(
             $configProvider,
             $productHelper,
+            $this->createMock(NetPriceCalculator::class),
+            new CashRounding(),
             $crossSellingBuilder,
             $this->createMock(\Shopware\Core\Framework\DataAbstractionLayer\EntityRepository::class),
         );
@@ -118,6 +127,8 @@ final class SkuBuilderTest extends TestCase
         $builder = new SkuBuilder(
             $configProvider,
             $productHelper,
+            $this->createMock(NetPriceCalculator::class),
+            new CashRounding(),
             $crossSellingBuilder,
             $this->createMock(\Shopware\Core\Framework\DataAbstractionLayer\EntityRepository::class),
         );
@@ -137,12 +148,69 @@ final class SkuBuilderTest extends TestCase
         self::assertSame('true', $customFields['Shipping Free'] ?? null);
     }
 
+    public function testBuildPrefersCalculatedPriceWhenMultiCurrencyIsDisabled(): void
+    {
+        $context = $this->createContext();
+        $product = $this->createProduct(
+            id: 'product-id',
+            productNumber: 'SWDEMO10004',
+            name: 'Calculated product',
+            stock: 1,
+            availableStock: 1,
+            priceCollection: $this->createPriceCollection('eur-id', 10.0, 12.0, 9.0, 11.0),
+        );
+
+        $configProvider = $this->createMock(ConfigProvider::class);
+        $configProvider->method('getProductIdentifier')->willReturn(ProductIdentifierOptions::PRODUCT_NUMBER);
+        $configProvider->method('getStockField')->willReturn(StockFieldOptions::ACTUAL_STOCK);
+        $configProvider->method('isEnabledProductProperties')->willReturn(false);
+        $configProvider->method('isEnabledInventoryLevels')->willReturn(false);
+        $configProvider->method('isEnabledProductLabellingSync')->willReturn(false);
+        $configProvider->method('isEnabledMultiCurrency')->willReturn(false);
+
+        $calculatedPrice = new CalculatedPrice(
+            25.0,
+            25.0,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection(),
+            1,
+            null,
+            ListPrice::createFromUnitPrice(25.0, 30.0),
+        );
+
+        $productHelper = $this->createMock(ProductHelper::class);
+        $productHelper->method('getProductUrl')->willReturn('https://shop.example.test/product/calculated');
+        $productHelper->method('getFallbackImageUrl')->willReturn('https://cdn.example.test/placeholder.svg');
+        $productHelper->expects($this->once())
+            ->method('getSalesChannelCalculatedPrice')
+            ->with('product-id', $context)
+            ->willReturn($calculatedPrice);
+
+        $crossSellingBuilder = $this->createMock(CrossSellingBuilder::class);
+        $crossSellingBuilder->method('build')->willReturn([]);
+
+        $builder = new SkuBuilder(
+            $configProvider,
+            $productHelper,
+            $this->createMock(NetPriceCalculator::class),
+            new CashRounding(),
+            $crossSellingBuilder,
+            $this->createMock(\Shopware\Core\Framework\DataAbstractionLayer\EntityRepository::class),
+        );
+
+        $sku = $builder->build($product, $context);
+
+        self::assertSame(25.0, $sku->getPrice());
+        self::assertSame(30.0, $sku->getListPrice());
+    }
+
     private function createContext(): SalesChannelContext
     {
         $context = $this->createMock(SalesChannelContext::class);
         $context->method('getSalesChannelId')->willReturn('sales-channel-id');
         $context->method('getLanguageId')->willReturn('language-id');
         $context->method('getCurrencyId')->willReturn('eur-id');
+        $context->method('getItemRounding')->willReturn(new CashRoundingConfig(2, 0.01, true));
 
         return $context;
     }

--- a/tests/Unit/Model/Operation/ProductSyncHandlerTest.php
+++ b/tests/Unit/Model/Operation/ProductSyncHandlerTest.php
@@ -6,6 +6,8 @@ namespace Nosto\NostoIntegration\Tests\Unit\Model\Operation;
 
 use Nosto\Model\Product\Product as NostoProduct;
 use Nosto\NostoIntegration\Model\ConfigProvider;
+use Nosto\NostoIntegration\Model\Nosto\Account;
+use Nosto\NostoIntegration\Model\Nosto\Account\KeyChain;
 use Nosto\NostoIntegration\Model\Nosto\Account\Provider as AccountProvider;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Helper\ProductHelper;
 use Nosto\NostoIntegration\Model\Nosto\Entity\Product\PartialProvider;
@@ -15,7 +17,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -60,6 +66,70 @@ final class ProductSyncHandlerTest extends TestCase
         self::assertNull($handler->validateProductPublic('SWDEMO10002', $product));
     }
 
+    public function testCreateAccountContextDoesNotOverrideDomainOrCurrencyWhenMultiCurrencyIsEnabled(): void
+    {
+        $account = new Account('sales-channel-id', 'language-id', 'account', new KeyChain([]));
+        $context = Context::createDefaultContext();
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+
+        $contextFactory = $this->createMock(AbstractSalesChannelContextFactory::class);
+        $contextFactory->expects($this->once())
+            ->method('create')
+            ->with(
+                $this->isType('string'),
+                'sales-channel-id',
+                $this->callback(static fn (array $parameters): bool => $parameters === [
+                    SalesChannelContextService::LANGUAGE_ID => 'language-id',
+                ]),
+            )
+            ->willReturn($salesChannelContext);
+
+        $configProvider = $this->createMock(ConfigProvider::class);
+        $configProvider->method('isEnabledMultiCurrency')->willReturn(true);
+        $configProvider->expects($this->never())->method('getDomainId');
+
+        $handler = $this->createHandler(
+            contextFactory: $contextFactory,
+            configProvider: $configProvider,
+        );
+
+        self::assertSame($salesChannelContext, $handler->createAccountContextPublic($account, $context));
+    }
+
+    public function testCreateAccountContextIgnoresInvalidDomainWhenMultiCurrencyIsDisabled(): void
+    {
+        $account = new Account('sales-channel-id', 'language-id', 'account', new KeyChain([]));
+        $context = Context::createDefaultContext();
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+
+        $contextFactory = $this->createMock(AbstractSalesChannelContextFactory::class);
+        $contextFactory->expects($this->once())
+            ->method('create')
+            ->with(
+                $this->isType('string'),
+                'sales-channel-id',
+                $this->callback(static fn (array $parameters): bool => $parameters === [
+                    SalesChannelContextService::LANGUAGE_ID => 'language-id',
+                ]),
+            )
+            ->willReturn($salesChannelContext);
+
+        $configProvider = $this->createMock(ConfigProvider::class);
+        $configProvider->method('isEnabledMultiCurrency')->willReturn(false);
+        $configProvider->method('getDomainId')->willReturn('invalid-domain-id');
+
+        $domainRepository = $this->createMock(EntityRepository::class);
+        $domainRepository->expects($this->never())->method('search');
+
+        $handler = $this->createHandler(
+            contextFactory: $contextFactory,
+            domainRepository: $domainRepository,
+            configProvider: $configProvider,
+        );
+
+        self::assertSame($salesChannelContext, $handler->createAccountContextPublic($account, $context));
+    }
+
     /**
      * @return iterable<string, array{0: string|null, 1: string|null, 2: string|null, 3: string}>
      */
@@ -87,13 +157,17 @@ final class ProductSyncHandlerTest extends TestCase
         ];
     }
 
-    private function createHandler(): TestableProductSyncHandler
-    {
+    private function createHandler(
+        ?AbstractSalesChannelContextFactory $contextFactory = null,
+        ?EntityRepository $domainRepository = null,
+        ?ConfigProvider $configProvider = null,
+    ): TestableProductSyncHandler {
         return new TestableProductSyncHandler(
-            $this->createMock(AbstractSalesChannelContextFactory::class),
+            $contextFactory ?? $this->createMock(AbstractSalesChannelContextFactory::class),
             $this->createMock(PartialProvider::class),
             $this->createMock(AccountProvider::class),
-            $this->createMock(ConfigProvider::class),
+            $domainRepository ?? $this->createMock(EntityRepository::class),
+            $configProvider ?? $this->createMock(ConfigProvider::class),
             $this->createMock(AbstractRuleLoader::class),
             $this->createMock(ProductHelper::class),
             $this->createMock(EventDispatcherInterface::class),
@@ -108,5 +182,10 @@ final class TestableProductSyncHandler extends ProductSyncHandler
     public function validateProductPublic(string $productNumber, NostoProduct $product): ?WarningMessage
     {
         return $this->validateProduct($productNumber, $product);
+    }
+
+    public function createAccountContextPublic(Account $account, Context $context): SalesChannelContext
+    {
+        return $this->createAccountContext($account, $context);
     }
 }


### PR DESCRIPTION
NS-14110: Fix Nosto product sync pricing for disabled multi-currency config and calculate price per domains currency
NS-14095: Fix sales-channel visibility filtering in Nosto product sync (When a product is not assigned to a sales channel it wont synced to Nosto)
NS-13557: Replace serialize/unserialize with clone to avoid fatal errors when Shopware context or criteria objects contain non-serializable values such as closures.