### PR TITLE
ADS-5437 Update MCP proxy to handle inconsistent response structures

### DIFF
--- a/src/Service/Mcp/NostoDocumentationMcpProxy.php
+++ b/src/Service/Mcp/NostoDocumentationMcpProxy.php
@@ -40,18 +40,18 @@ final class NostoDocumentationMcpProxy
             $requestArguments = $requestPayload['arguments'] ?? [];
 
             if (!\is_array($requestArguments)) {
-                $this->logger->error('Arguments payload is not an array', ['type' => gettype($requestArguments)]);
                 return $this->errorResult('The arguments payload must be an object.');
             }
 
             $documentationQuery = $this->extractDocumentationQuery($requestArguments);
             if ($documentationQuery === null) {
-                $this->logger->error('No query argument found', ['arguments' => array_keys($requestArguments)]);
                 return $this->errorResult('The query argument is required.');
             }
 
             $mcpSessionId = $this->initializeMcpSession();
-            $this->logger->info('MCP session initialized', ['sessionId' => $mcpSessionId]);
+            $this->logger->info('MCP session initialized', [
+                'sessionId' => $mcpSessionId,
+            ]);
             $this->sendInitializedNotification($mcpSessionId);
             $toolsList = $this->listRemoteTools($mcpSessionId);
             $response = $this->callRemoteDocumentationTool($mcpSessionId, $resolvedToolName, $documentationQuery);
@@ -160,7 +160,6 @@ final class NostoDocumentationMcpProxy
         try {
             $body = json_encode($jsonRpcPayload, \JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
-            $this->logger->error('Failed to encode JSON-RPC payload', ['error' => $e->getMessage()]);
             throw new \RuntimeException('Could not encode the Nosto MCP request payload.', 0, $e);
         }
 

--- a/src/Service/Mcp/NostoDocumentationMcpProxy.php
+++ b/src/Service/Mcp/NostoDocumentationMcpProxy.php
@@ -40,23 +40,32 @@ final class NostoDocumentationMcpProxy
             $requestArguments = $requestPayload['arguments'] ?? [];
 
             if (!\is_array($requestArguments)) {
+                $this->logger->error('Arguments payload is not an array', ['type' => gettype($requestArguments)]);
                 return $this->errorResult('The arguments payload must be an object.');
             }
 
             $documentationQuery = $this->extractDocumentationQuery($requestArguments);
             if ($documentationQuery === null) {
+                $this->logger->error('No query argument found', ['arguments' => array_keys($requestArguments)]);
                 return $this->errorResult('The query argument is required.');
             }
 
             $mcpSessionId = $this->initializeMcpSession();
+            $this->logger->info('MCP session initialized', ['sessionId' => $mcpSessionId]);
             $this->sendInitializedNotification($mcpSessionId);
+            $toolsList = $this->listRemoteTools($mcpSessionId);
             $response = $this->callRemoteDocumentationTool($mcpSessionId, $resolvedToolName, $documentationQuery);
         } catch (\InvalidArgumentException $e) {
+            $this->logger->warning('Invalid argument in documentation request', [
+                'exception' => $e->getMessage(),
+            ]);
+
             return $this->errorResult($e->getMessage());
         } catch (Throwable $e) {
             $this->logger->error('Failed to proxy the Nosto MCP documentation request.', [
                 'exception' => $e,
                 'tool' => $requestPayload['tool'] ?? null,
+                'mcpServerUrl' => $this->mcpServerUrl,
             ]);
 
             return $this->errorResult('Failed to fetch documentation from the Nosto MCP server.');
@@ -89,17 +98,27 @@ final class NostoDocumentationMcpProxy
      */
     private function callRemoteDocumentationTool(string $mcpSessionId, string $toolName, string $query): array
     {
-        return $this->sendJsonRpcRequest('tools/call', [
+        $toolCallPayload = [
             'name' => $toolName,
             'arguments' => [
                 'query_input' => $query,
             ],
-        ], $mcpSessionId);
+        ];
+
+        return $this->sendJsonRpcRequest('tools/call', $toolCallPayload, $mcpSessionId);
     }
 
     private function sendInitializedNotification(string $mcpSessionId): void
     {
         $this->sendJsonRpcRequest('notifications/initialized', [], $mcpSessionId, true);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listRemoteTools(string $mcpSessionId): array
+    {
+        return $this->sendJsonRpcRequest('tools/list', [], $mcpSessionId);
     }
 
     /**
@@ -113,7 +132,6 @@ final class NostoDocumentationMcpProxy
 
         if (isset($response['error']) && \is_array($response['error'])) {
             $message = $response['error']['message'] ?? 'The Nosto MCP server returned an error.';
-
             return $this->errorResult((string) $message);
         }
 
@@ -132,7 +150,7 @@ final class NostoDocumentationMcpProxy
         $jsonRpcPayload = [
             'jsonrpc' => '2.0',
             'method' => $method,
-            'params' => $params,
+            'params' => (object) $params,
         ];
 
         if (!$isNotification) {
@@ -142,6 +160,7 @@ final class NostoDocumentationMcpProxy
         try {
             $body = json_encode($jsonRpcPayload, \JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
+            $this->logger->error('Failed to encode JSON-RPC payload', ['error' => $e->getMessage()]);
             throw new \RuntimeException('Could not encode the Nosto MCP request payload.', 0, $e);
         }
 

--- a/src/Service/Mcp/NostoDocumentationMcpProxy.php
+++ b/src/Service/Mcp/NostoDocumentationMcpProxy.php
@@ -49,9 +49,6 @@ final class NostoDocumentationMcpProxy
             }
 
             $mcpSessionId = $this->initializeMcpSession();
-            $this->logger->info('MCP session initialized', [
-                'sessionId' => $mcpSessionId,
-            ]);
             $this->sendInitializedNotification($mcpSessionId);
             $toolsList = $this->listRemoteTools($mcpSessionId);
             $response = $this->callRemoteDocumentationTool($mcpSessionId, $resolvedToolName, $documentationQuery);

--- a/tests/Unit/Api/Controller/NostoMcpControllerTest.php
+++ b/tests/Unit/Api/Controller/NostoMcpControllerTest.php
@@ -89,6 +89,31 @@ final class NostoMcpControllerTest extends TestCase
                 ]);
             }
 
+            if (($payload['method'] ?? null) === 'tools/list') {
+                return new MockResponse(
+                    json_encode([
+                        'jsonrpc' => '2.0',
+                        'id' => $payload['id'] ?? 2,
+                        'result' => [
+                            'tools' => [
+                                [
+                                    'name' => 'get_nosto_tech_docs',
+                                ],
+                                [
+                                    'name' => 'get_nosto_feature_docs',
+                                ],
+                            ],
+                        ],
+                    ], \JSON_THROW_ON_ERROR),
+                    [
+                        'http_code' => 200,
+                        'response_headers' => [
+                            'content-type' => 'application/json',
+                        ],
+                    ],
+                );
+            }
+
             if (($payload['method'] ?? null) === 'tools/call') {
                 return new MockResponse(
                     json_encode([

--- a/tests/Unit/Mcp/NostoDocumentationSearchToolTest.php
+++ b/tests/Unit/Mcp/NostoDocumentationSearchToolTest.php
@@ -59,6 +59,31 @@ final class NostoDocumentationSearchToolTest extends TestCase
                 ]);
             }
 
+            if (($payload['method'] ?? null) === 'tools/list') {
+                return new MockResponse(
+                    json_encode([
+                        'jsonrpc' => '2.0',
+                        'id' => $payload['id'] ?? 2,
+                        'result' => [
+                            'tools' => [
+                                [
+                                    'name' => 'get_nosto_tech_docs',
+                                ],
+                                [
+                                    'name' => 'get_nosto_feature_docs',
+                                ],
+                            ],
+                        ],
+                    ], \JSON_THROW_ON_ERROR),
+                    [
+                        'http_code' => 200,
+                        'response_headers' => [
+                            'content-type' => 'application/json',
+                        ],
+                    ],
+                );
+            }
+
             self::assertSame('tools/call', $payload['method'] ?? null);
             self::assertSame('get_nosto_tech_docs', $payload['params']['name'] ?? null);
             self::assertSame('How do I expose docs MCP?', $payload['params']['arguments']['query_input'] ?? null);
@@ -93,7 +118,7 @@ final class NostoDocumentationSearchToolTest extends TestCase
         $result = $tool('How do I expose docs MCP?');
 
         self::assertSame('Use the MCP endpoint and a proxy service.', $result);
-        self::assertCount(3, $requests);
+        self::assertCount(4, $requests);
     }
 
     public function testUsesFeatureDocumentationWhenRequested(): void
@@ -142,6 +167,31 @@ final class NostoDocumentationSearchToolTest extends TestCase
                 ]);
             }
 
+            if (($payload['method'] ?? null) === 'tools/list') {
+                return new MockResponse(
+                    json_encode([
+                        'jsonrpc' => '2.0',
+                        'id' => $payload['id'] ?? 2,
+                        'result' => [
+                            'tools' => [
+                                [
+                                    'name' => 'get_nosto_tech_docs',
+                                ],
+                                [
+                                    'name' => 'get_nosto_feature_docs',
+                                ],
+                            ],
+                        ],
+                    ], \JSON_THROW_ON_ERROR),
+                    [
+                        'http_code' => 200,
+                        'response_headers' => [
+                            'content-type' => 'application/json',
+                        ],
+                    ],
+                );
+            }
+
             self::assertSame('tools/call', $payload['method'] ?? null);
             self::assertSame('get_nosto_feature_docs', $payload['params']['name'] ?? null);
             self::assertSame('How do I expose docs MCP?', $payload['params']['arguments']['query_input'] ?? null);
@@ -176,6 +226,6 @@ final class NostoDocumentationSearchToolTest extends TestCase
         $result = $tool('How do I expose docs MCP?', 'feature');
 
         self::assertSame('Feature docs result.', $result);
-        self::assertCount(3, $requests);
+        self::assertCount(4, $requests);
     }
 }

--- a/tests/Unit/Service/Mcp/NostoDocumentationMcpProxyTest.php
+++ b/tests/Unit/Service/Mcp/NostoDocumentationMcpProxyTest.php
@@ -79,8 +79,12 @@ final class NostoDocumentationMcpProxyTest extends TestCase
                         'id' => $payload['id'] ?? 2,
                         'result' => [
                             'tools' => [
-                                ['name' => 'get_nosto_tech_docs'],
-                                ['name' => 'get_nosto_feature_docs'],
+                                [
+                                    'name' => 'get_nosto_tech_docs',
+                                ],
+                                [
+                                    'name' => 'get_nosto_feature_docs',
+                                ],
                             ],
                         ],
                     ], \JSON_THROW_ON_ERROR),
@@ -202,8 +206,12 @@ final class NostoDocumentationMcpProxyTest extends TestCase
                         'id' => $payload['id'] ?? 2,
                         'result' => [
                             'tools' => [
-                                ['name' => 'get_nosto_tech_docs'],
-                                ['name' => 'get_nosto_feature_docs'],
+                                [
+                                    'name' => 'get_nosto_tech_docs',
+                                ],
+                                [
+                                    'name' => 'get_nosto_feature_docs',
+                                ],
                             ],
                         ],
                     ], \JSON_THROW_ON_ERROR),
@@ -316,7 +324,9 @@ final class NostoDocumentationMcpProxyTest extends TestCase
                         'id' => $payload['id'] ?? 2,
                         'result' => [
                             'tools' => [
-                                ['name' => 'get_nosto_tech_docs'],
+                                [
+                                    'name' => 'get_nosto_tech_docs',
+                                ],
                             ],
                         ],
                     ], \JSON_THROW_ON_ERROR),

--- a/tests/Unit/Service/Mcp/NostoDocumentationMcpProxyTest.php
+++ b/tests/Unit/Service/Mcp/NostoDocumentationMcpProxyTest.php
@@ -56,6 +56,8 @@ final class NostoDocumentationMcpProxyTest extends TestCase
                     'Mcp-Session-Id: session-123',
                     $options['normalized_headers']['mcp-session-id'][0] ?? null,
                 );
+                self::assertFalse(isset($payload['id']), 'Notifications must not include id field');
+                self::assertIsArray($payload['params'] ?? null, 'Params must be an object (decoded as array)');
 
                 return new MockResponse('', [
                     'http_code' => 200,
@@ -63,6 +65,32 @@ final class NostoDocumentationMcpProxyTest extends TestCase
                         'content-type' => 'application/json',
                     ],
                 ]);
+            }
+
+            if (($payload['method'] ?? null) === 'tools/list') {
+                self::assertSame(
+                    'Mcp-Session-Id: session-123',
+                    $options['normalized_headers']['mcp-session-id'][0] ?? null,
+                );
+
+                return new MockResponse(
+                    json_encode([
+                        'jsonrpc' => '2.0',
+                        'id' => $payload['id'] ?? 2,
+                        'result' => [
+                            'tools' => [
+                                ['name' => 'get_nosto_tech_docs'],
+                                ['name' => 'get_nosto_feature_docs'],
+                            ],
+                        ],
+                    ], \JSON_THROW_ON_ERROR),
+                    [
+                        'http_code' => 200,
+                        'response_headers' => [
+                            'content-type' => 'application/json',
+                        ],
+                    ],
+                );
             }
 
             self::assertSame('tools/call', $payload['method'] ?? null);
@@ -106,7 +134,7 @@ final class NostoDocumentationMcpProxyTest extends TestCase
 
         self::assertSame('Use the MCP endpoint and a proxy service.', $result['content'][0]['text']);
         self::assertFalse($result['isError']);
-        self::assertCount(3, $requests);
+        self::assertCount(4, $requests);
     }
 
     public function testForwardsFeatureDocumentationQueriesToTheRemoteMcpServer(): void
@@ -151,6 +179,8 @@ final class NostoDocumentationMcpProxyTest extends TestCase
                     'Mcp-Session-Id: session-456',
                     $options['normalized_headers']['mcp-session-id'][0] ?? null,
                 );
+                self::assertFalse(isset($payload['id']), 'Notifications must not include id field');
+                self::assertIsArray($payload['params'] ?? null, 'Params must be an object (decoded as array)');
 
                 return new MockResponse('', [
                     'http_code' => 200,
@@ -158,6 +188,32 @@ final class NostoDocumentationMcpProxyTest extends TestCase
                         'content-type' => 'application/json',
                     ],
                 ]);
+            }
+
+            if (($payload['method'] ?? null) === 'tools/list') {
+                self::assertSame(
+                    'Mcp-Session-Id: session-456',
+                    $options['normalized_headers']['mcp-session-id'][0] ?? null,
+                );
+
+                return new MockResponse(
+                    json_encode([
+                        'jsonrpc' => '2.0',
+                        'id' => $payload['id'] ?? 2,
+                        'result' => [
+                            'tools' => [
+                                ['name' => 'get_nosto_tech_docs'],
+                                ['name' => 'get_nosto_feature_docs'],
+                            ],
+                        ],
+                    ], \JSON_THROW_ON_ERROR),
+                    [
+                        'http_code' => 200,
+                        'response_headers' => [
+                            'content-type' => 'application/json',
+                        ],
+                    ],
+                );
             }
 
             self::assertSame('tools/call', $payload['method'] ?? null);
@@ -201,7 +257,7 @@ final class NostoDocumentationMcpProxyTest extends TestCase
 
         self::assertSame('Feature docs result.', $result['content'][0]['text']);
         self::assertFalse($result['isError']);
-        self::assertCount(3, $requests);
+        self::assertCount(4, $requests);
     }
 
     public function testParsesSseToolsCallResponse(): void
@@ -242,12 +298,35 @@ final class NostoDocumentationMcpProxyTest extends TestCase
             }
 
             if (($payload['method'] ?? null) === 'notifications/initialized') {
+                self::assertFalse(isset($payload['id']), 'Notifications must not include id field');
+                self::assertIsArray($payload['params'] ?? null, 'Params must be an object (decoded as array)');
+
                 return new MockResponse('', [
                     'http_code' => 200,
                     'response_headers' => [
                         'content-type' => 'application/json',
                     ],
                 ]);
+            }
+
+            if (($payload['method'] ?? null) === 'tools/list') {
+                return new MockResponse(
+                    json_encode([
+                        'jsonrpc' => '2.0',
+                        'id' => $payload['id'] ?? 2,
+                        'result' => [
+                            'tools' => [
+                                ['name' => 'get_nosto_tech_docs'],
+                            ],
+                        ],
+                    ], \JSON_THROW_ON_ERROR),
+                    [
+                        'http_code' => 200,
+                        'response_headers' => [
+                            'content-type' => 'application/json',
+                        ],
+                    ],
+                );
             }
 
             return new MockResponse(
@@ -272,7 +351,7 @@ final class NostoDocumentationMcpProxyTest extends TestCase
 
         self::assertSame('ok', $result['content'][0]['text']);
         self::assertFalse($result['isError']);
-        self::assertCount(3, $requests);
+        self::assertCount(4, $requests);
     }
 
     public function testReturnsMcpErrorForInvalidToolPayload(): void


### PR DESCRIPTION
[ADS-5437](https://nostosolutions.atlassian.net/browse/ADS-5437)
### The Problem:
The Nosto MCP documentation search was failing with "Invalid request parameters" (HTTP 400 / JSON-RPC -32602 errors). The root causes were:

### Incorrect JSON-RPC Format
- Request parameters were being sent as an empty array [] instead of an object {}
- This caused the Nosto MCP server to reject requests during validation
### Broken Session Initialization
- The notifications/initialized request was incorrectly including an id field
- According to JSON-RPC 2.0 spec, notifications should NOT have an id field
- This caused the server to reject the notification, preventing tool registration
- As a result, tools/list returned an empty array, and tools/call had no tools to execute

[ADS-5437]: https://nostosolutions.atlassian.net/browse/ADS-5437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ