### PR TITLE
update store validator shop version to 6.6.10.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Shopware Shop
         uses: ./nosto-shopware6/.github/action/setup_shop
         with:
-          shopware-version: '6.6.2.0'
+          shopware-version: '6.6.10.10'
 
       - name: Build admin + storefront assets
         run: |


### PR DESCRIPTION
Update Shopware version to 6.6.10.10 in release workflow (version 6.6.2.0 is blocked by Packagist security advisories)