### PR TITLE
ADS-5261 Support keyword facets v5

### DIFF
--- a/src/Decorator/Storefront/Controller/SearchController.php
+++ b/src/Decorator/Storefront/Controller/SearchController.php
@@ -96,9 +96,12 @@ class SearchController extends StorefrontController
             return $this->forwardToRoute('frontend.home.page');
         }
 
-        /** @var Redirect $redirect */
-        if ($redirect = $context->getContext()->getExtension('nostoRedirect')) {
-            return $this->redirect($redirect->getLink(), 301);
+        $redirect = $context->getContext()->getExtension('nostoRedirect');
+        if ($redirect instanceof Redirect) {
+            // Canonicalised filter URLs are temporary: a facet id changes when the merchant
+            // recreates the facet, and a cached 301 would pin the stale id. Merchant redirect
+            // rules stay permanent.
+            return $this->redirect($redirect->getLink(), $redirect->isPermanent() ? 301 : 302);
         }
 
         $this->hook(new SearchPageLoadedHook($page, $context));

--- a/src/Search/Request/Handler/AbstractRequestHandler.php
+++ b/src/Search/Request/Handler/AbstractRequestHandler.php
@@ -72,6 +72,12 @@ abstract class AbstractRequestHandler
                 return;
             }
 
+            // Runs after the merchant redirect rules, which keep priority.
+            if ($canonical = $this->buildCanonicalFilterUrl($request, $criteria)) {
+                $this->handleRedirect($context, new Redirect($canonical, false));
+                return;
+            }
+
             $this->updateCriteriaWithProductIds($criteria, $responseParser);
             if (!is_null($criteria->getLimit()) && !is_null($criteria->getOffset())) {
                 $this->setPagination(
@@ -125,6 +131,22 @@ abstract class AbstractRequestHandler
         $request->attributes->set(
             'setNostoCookie',
             json_encode($filterMapping->getMap(), JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /**
+     * The mapping is only present once handleFiltersAndMapping() has run, which requires a
+     * non-empty product result. A zero-result filtered search therefore does not canonicalise.
+     */
+    private function buildCanonicalFilterUrl(Request $request, Criteria $criteria): ?string
+    {
+        $mapping = $criteria->getExtension('nostoFilterMapping');
+        $queryString = $request->server->get('QUERY_STRING');
+
+        return (new CanonicalFilterUrlBuilder())->build(
+            $request->getPathInfo(),
+            is_string($queryString) ? $queryString : null,
+            $mapping instanceof IdToFieldMapping ? $mapping : null,
         );
     }
 

--- a/src/Search/Request/Handler/CanonicalFilterUrlBuilder.php
+++ b/src/Search/Request/Handler/CanonicalFilterUrlBuilder.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Search\Request\Handler;
+
+use Nosto\NostoIntegration\Struct\IdToFieldMapping;
+
+/**
+ * Rewrites Nosto field-path filter parameters into the canonical facet-id parameters the
+ * storefront filter panel understands.
+ *
+ * Nosto's autocomplete emits `?products.filter.<field>=<value>`, but the filter panel computes
+ * its selected state client-side from window.location.search keyed by facet id, and Shopware's
+ * listing JS rebuilds the query string from registered filter plugins only — so a field-path
+ * parameter is invisible to the panel and is dropped on the shopper's first interaction.
+ * Redirecting to the canonical URL fixes both, and removes the need for merchants to maintain a
+ * `serpUrlMapping` in their Nosto search templates. See ADS-5261.
+ */
+class CanonicalFilterUrlBuilder
+{
+    /**
+     * Mirrors FilterHandler::MIN_PREFIX / ::MAX_PREFIX, which are protected there and so cannot
+     * be reused from the outside. Keep the two in sync.
+     */
+    protected const MIN_PREFIX = 'min-';
+
+    protected const MAX_PREFIX = 'max-';
+
+    public function __construct(
+        private readonly NostoFieldFilterParser $parser = new NostoFieldFilterParser(),
+    ) {
+    }
+
+    /**
+     * Returns the canonical URL for $path + $queryString, or null when there is nothing to
+     * canonicalise — no field-path filters, or none of them resolves to a known facet id.
+     * Returning null is important: it prevents a pointless redirect, and a redirect loop.
+     */
+    public function build(string $path, ?string $queryString, ?IdToFieldMapping $mapping): ?string
+    {
+        // After a redirect the URL carries no 'products.filter.*' parameter any more, so this
+        // returns [] and no second redirect can be issued. That is the loop guard.
+        if ($this->parser->parseQueryString($queryString) === []) {
+            return null;
+        }
+
+        if ($mapping === null) {
+            return null;
+        }
+
+        /** @var array<string, string> $facetIdsByField */
+        $facetIdsByField = array_flip($mapping->getMap());
+
+        $pairs = [];
+        $rewritten = false;
+
+        foreach (explode('&', (string) $queryString) as $pair) {
+            if ($pair === '') {
+                continue;
+            }
+
+            $canonical = $this->canonicalise($pair, $facetIdsByField);
+
+            if ($canonical === null) {
+                // Not a resolvable field-path filter: keep the shopper's parameter untouched.
+                // Re-encoding it would risk changing values that are already correctly escaped.
+                $pairs[] = $pair;
+                continue;
+            }
+
+            foreach ($canonical as $canonicalPair) {
+                $pairs[] = $canonicalPair;
+            }
+
+            $rewritten = true;
+        }
+
+        if (!$rewritten) {
+            return null;
+        }
+
+        return $path . '?' . implode('&', $pairs);
+    }
+
+    /**
+     * @param array<string, string> $facetIdsByField
+     * @return string[]|null the canonical replacement pairs, or null when $pair must be kept
+     *                       verbatim. An empty array means the parameter is dropped, which
+     *                       happens only for an unparseable field-path parameter that could
+     *                       not have been applied as a filter either.
+     */
+    private function canonicalise(string $pair, array $facetIdsByField): ?array
+    {
+        if (!str_contains($pair, '=')) {
+            return null;
+        }
+
+        [$name, $value] = explode('=', $pair, 2);
+
+        $name = urldecode($name);
+        if (!NostoFieldFilterParser::supports($name)) {
+            return null;
+        }
+
+        // Exactly one urldecode per value, matching NostoFieldFilterParser::parseQueryString():
+        // a literal '~' inside a value arrives double-encoded and must stay '%7E' here.
+        $filter = $this->parser->parse($name, urldecode($value));
+        if ($filter === null) {
+            return [];
+        }
+
+        $facetId = $facetIdsByField[$filter->field] ?? null;
+        if ($facetId === null || $facetId === '') {
+            return null;
+        }
+
+        return $filter->isRange()
+            ? $this->rangePairs($facetId, $filter)
+            : $this->valuePairs($facetId, $filter);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function valuePairs(string $facetId, NostoFieldFilter $filter): array
+    {
+        return [
+            urlencode($facetId) . '=' . urlencode(implode(FilterHandler::FILTER_DELIMITER, $filter->values)),
+        ];
+    }
+
+    /**
+     * Only the first range is representable, exactly as FilterHandler does when applying it.
+     * The panel has no exclusive form, so an exclusive bound canonicalises to an inclusive one.
+     *
+     * @return string[]
+     */
+    private function rangePairs(string $facetId, NostoFieldFilter $filter): array
+    {
+        $range = $filter->ranges[0];
+        $lower = $range['gte'] ?? $range['gt'] ?? null;
+        $upper = $range['lte'] ?? $range['lt'] ?? null;
+
+        $pairs = [];
+
+        if ($lower !== null) {
+            $pairs[] = self::MIN_PREFIX . urlencode($facetId) . '=' . urlencode($lower);
+        }
+        if ($upper !== null) {
+            $pairs[] = self::MAX_PREFIX . urlencode($facetId) . '=' . urlencode($upper);
+        }
+
+        return $pairs;
+    }
+}

--- a/src/Search/Request/Handler/FilterHandler.php
+++ b/src/Search/Request/Handler/FilterHandler.php
@@ -24,9 +24,12 @@ class FilterHandler
 
     protected const MAX_PREFIX = 'max-';
 
+    private readonly NostoFieldFilterParser $fieldFilterParser;
+
     public function __construct(
         private readonly FilterPayloadService $filterPayloadService,
     ) {
+        $this->fieldFilterParser = new NostoFieldFilterParser();
     }
 
     /**
@@ -39,7 +42,15 @@ class FilterHandler
         SearchOperation $searchOperation,
         bool $newRequest = true,
     ): void {
-        $selectedFilters = $request->query->all();
+        // Keep $selectedFilters free of the PHP-mangled 'products_filter_*' keys, so a request
+        // that only carries field-path filters takes the early return below instead of running
+        // the id-keyed pass (which, on the cookie path, costs a resolveCookiePayload() lookup).
+        $selectedFilters = $this->withoutFieldPathParameters($request->query->all());
+
+        // Nosto's autocomplete and SERP links key filters by field path rather than facet id.
+        // They must be read from the raw query string: PHP rewrites '.' to '_' in parameter
+        // names, so they are not visible in $request->query at all. See ADS-5261.
+        $this->applyFieldPathFilters($request, $searchOperation);
 
         if (empty($selectedFilters)) {
             return;
@@ -49,6 +60,94 @@ class FilterHandler
             $this->handleNewRequest($selectedFilters, $criteria, $searchOperation);
         } else {
             $this->handleExistingRequest($selectedFilters, $request, $searchOperation);
+        }
+    }
+
+    // Selected-state rendering for these filters is deliberately not handled here; the panel
+    // computes it client-side from window.location.search. See ADS-5261 follow-up 3.
+    private function applyFieldPathFilters(Request $request, SearchOperation $searchOperation): void
+    {
+        $queryString = $request->server->get('QUERY_STRING');
+
+        $filters = $this->fieldFilterParser->parseQueryString(
+            is_string($queryString) ? $queryString : null,
+        );
+
+        // SearchOperation merges ranges per field, so a repeated parameter name would silently
+        // overwrite the bounds of the earlier one. Keep the first range per field, which matches
+        // how multiple ranges inside a single value are handled.
+        $rangedFields = [];
+
+        foreach ($filters as $filter) {
+            $this->applyFieldFilter($filter, $searchOperation, $rangedFields);
+        }
+    }
+
+    /**
+     * Drops the PHP-mangled counterparts of the field-path parameters (dots rewritten to
+     * underscores), so a field-path-only request leaves no id-keyed parameters behind and can
+     * skip the id-based pass entirely.
+     *
+     * @param array<string, mixed> $selectedFilters
+     * @return array<string, mixed>
+     */
+    private function withoutFieldPathParameters(array $selectedFilters): array
+    {
+        $remaining = [];
+
+        foreach ($selectedFilters as $filterId => $filterValues) {
+            if (is_string($filterId) && str_starts_with($filterId, NostoFieldFilterParser::MANGLED_FIELD_PREFIX)) {
+                continue;
+            }
+
+            $remaining[$filterId] = $filterValues;
+        }
+
+        return $remaining;
+    }
+
+    /**
+     * @param array<string, true> $rangedFields fields that already had a range applied in this
+     *                                          request, by reference so later duplicates of the
+     *                                          same parameter name can be skipped
+     */
+    private function applyFieldFilter(
+        NostoFieldFilter $filter,
+        SearchOperation $searchOperation,
+        array &$rangedFields = [],
+    ): void {
+        // Rating is a stats facet in Nosto: the pre-existing facet-id route sends it through
+        // addRangeFilter() as a lower bound, and a value filter would match nothing.
+        if (!$filter->isRange() && $this->isRatingFilter($filter->field)) {
+            foreach ($filter->values as $value) {
+                $this->handleRatingFilter($filter->field, $value, $searchOperation);
+            }
+
+            return;
+        }
+
+        if ($filter->isRange()) {
+            if (isset($rangedFields[$filter->field])) {
+                return;
+            }
+
+            $rangedFields[$filter->field] = true;
+
+            // addRangeFilter() merges into one range per field, so only the first range is
+            // representable. Applying the rest would corrupt the bounds.
+            $range = $filter->ranges[0];
+
+            $searchOperation->addRangeFilter(
+                $filter->field,
+                $range['gte'] ?? $range['gt'] ?? null,
+                $range['lte'] ?? $range['lt'] ?? null,
+            );
+
+            return;
+        }
+
+        foreach ($filter->values as $value) {
+            $searchOperation->addValueFilter($filter->field, $value);
         }
     }
 

--- a/src/Search/Request/Handler/NostoFieldFilter.php
+++ b/src/Search/Request/Handler/NostoFieldFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Search\Request\Handler;
+
+/**
+ * A single filter decoded from a `products.filter.<field>` query parameter.
+ *
+ * Either $values is non-empty (a terms filter) or $ranges is non-empty (a stats filter),
+ * never both. Each range is a map with any of the keys 'gt', 'gte', 'lt', 'lte'.
+ */
+final class NostoFieldFilter
+{
+    /**
+     * @param string[] $values
+     * @param array<int, array<string, string>> $ranges
+     */
+    public function __construct(
+        public readonly string $field,
+        public readonly array $values = [],
+        public readonly array $ranges = [],
+    ) {
+    }
+
+    public function isRange(): bool
+    {
+        return $this->ranges !== [];
+    }
+}

--- a/src/Search/Request/Handler/NostoFieldFilterParser.php
+++ b/src/Search/Request/Handler/NostoFieldFilterParser.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Search\Request\Handler;
+
+/**
+ * Decodes Nosto search-js filter query parameters into NostoFieldFilter objects.
+ *
+ * Nosto's autocomplete and SERP links serialise filters keyed by the Nosto field path
+ * rather than by facet id, e.g.:
+ *
+ *     ?products.filter.skus.customFields.größe=100x200cm
+ *
+ * This class is intentionally dependency-free so the (fiddly) format rules are covered
+ * by plain unit tests.
+ */
+class NostoFieldFilterParser
+{
+    public const FIELD_PREFIX = 'products.filter.';
+
+    public const VALUE_DELIMITER = '||';
+
+    protected const ESCAPED_TILDE = '%7E';
+
+    protected const RANGE_SEPARATOR = '~';
+
+    protected const LEGACY_RANGE_SEPARATOR = '-+';
+
+    protected const RANGE_DELIMITER = ',';
+
+    protected const SEGMENT_DOT_ESCAPE = '::';
+
+    /**
+     * A Nosto field path is a dot-separated list of attribute names, e.g.
+     * 'skus.customFields.größe'. Anything else is a malformed or hostile parameter and must
+     * not reach the Nosto API. Unicode letters are allowed because merchants use localised
+     * custom-field names.
+     */
+    protected const FIELD_PATTERN = '/^[\p{L}\p{N}_.\- ]{1,128}$/u';
+
+    /**
+     * PHP rewrites '.' to '_' in query-parameter names, so the same parameter also appears
+     * in $request->query under this mangled prefix. Callers use this to discard it.
+     */
+    public const MANGLED_FIELD_PREFIX = 'products_filter_';
+
+    public static function supports(string $key): bool
+    {
+        return str_starts_with($key, self::FIELD_PREFIX);
+    }
+
+    /**
+     * Decodes every Nosto field-path filter out of a raw query string.
+     *
+     * This MUST be given the raw query string (Symfony: $request->server->get('QUERY_STRING')),
+     * not $request->query. PHP rewrites '.' to '_' in parameter names, so a parameter named
+     * 'products.filter.brand' is only ever visible as 'products_filter_brand' in the parsed
+     * bag and could never be recognised.
+     *
+     * Exactly one urldecode is applied per name and per value. That is deliberate: Nosto
+     * escapes a literal '~' in a value to the text '%7E' before percent-encoding, so it
+     * arrives here double-encoded and must still be '%7E' when parseValues() runs. Decoding
+     * twice would turn a literal tilde into a range separator.
+     *
+     * It must be urldecode() and not rawurldecode(): under form-urlencoding '+' means space,
+     * so rawurldecode() would break every value containing one ('Blue Steel' arrives as
+     * 'Blue+Steel'). The legacy '-+' range separator is therefore sent as '10-%2B20', which
+     * urldecode() restores correctly.
+     *
+     * @return NostoFieldFilter[]
+     */
+    public function parseQueryString(?string $queryString): array
+    {
+        if ($queryString === null || $queryString === '') {
+            return [];
+        }
+
+        $filters = [];
+
+        foreach (explode('&', $queryString) as $pair) {
+            if ($pair === '' || !str_contains($pair, '=')) {
+                continue;
+            }
+
+            [$name, $value] = explode('=', $pair, 2);
+
+            $name = urldecode($name);
+            if (!self::supports($name)) {
+                continue;
+            }
+
+            $filter = $this->parse($name, urldecode($value));
+            if ($filter !== null) {
+                $filters[] = $filter;
+            }
+        }
+
+        return $filters;
+    }
+
+    public function parse(string $key, string $rawValue): ?NostoFieldFilter
+    {
+        if (!self::supports($key)) {
+            return null;
+        }
+
+        $field = str_replace(
+            self::SEGMENT_DOT_ESCAPE,
+            '.',
+            mb_substr($key, mb_strlen(self::FIELD_PREFIX)),
+        );
+        if ($field === '' || $rawValue === '') {
+            return null;
+        }
+
+        if (preg_match(self::FIELD_PATTERN, $field) !== 1) {
+            return null;
+        }
+
+        $ranges = $this->parseRanges($rawValue);
+        if ($ranges !== []) {
+            return new NostoFieldFilter($field, [], $ranges);
+        }
+
+        $values = $this->parseValues($rawValue);
+        if ($values === []) {
+            return null;
+        }
+
+        return new NostoFieldFilter($field, $values);
+    }
+
+    /**
+     * Nosto joins multiple values for one field with '||' and escapes any literal '~'
+     * (its range separator) as '%7E'.
+     *
+     * @return string[]
+     */
+    protected function parseValues(string $rawValue): array
+    {
+        $values = [];
+
+        foreach (explode(self::VALUE_DELIMITER, $rawValue) as $value) {
+            $value = str_replace(self::ESCAPED_TILDE, '~', $value);
+            if ($value !== '') {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Nosto serialises a range as '<lower><separator><upper>', with square brackets marking
+     * an exclusive bound: '[10~20]' means gt=10, lt=20 while '10~20' means gte=10, lte=20.
+     * Multiple ranges for one field are comma-separated. A literal '~' inside a value is
+     * escaped as '%7E', so an unescaped separator is what distinguishes a range from a value.
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function parseRanges(string $rawValue): array
+    {
+        $separator = match (true) {
+            str_contains($rawValue, self::LEGACY_RANGE_SEPARATOR) => self::LEGACY_RANGE_SEPARATOR,
+            str_contains($rawValue, self::RANGE_SEPARATOR) => self::RANGE_SEPARATOR,
+            default => null,
+        };
+
+        if ($separator === null) {
+            return [];
+        }
+
+        $ranges = [];
+
+        foreach (explode(self::RANGE_DELIMITER, $rawValue) as $rawRange) {
+            if ($rawRange === '') {
+                continue; // an empty segment carries no information
+            }
+
+            $range = $this->parseRange($rawRange, $separator);
+            if ($range === []) {
+                // A non-empty unparseable segment means this is not a range parameter.
+                return [];
+            }
+
+            $ranges[] = $range;
+        }
+
+        return $ranges;
+    }
+
+    /**
+     * A range bound is always numeric in this format. Anything else means the parameter is
+     * not really a range (e.g. 'abc~def', or '10~20||30' where a value delimiter leaks in),
+     * and the caller falls back to treating it as a value. That keeps malformed, user-supplied
+     * URLs from sending nonsense bounds to the Nosto API.
+     *
+     * @return array<string, string>
+     */
+    protected function parseRange(string $rawRange, string $separator): array
+    {
+        if (!str_contains($rawRange, $separator)) {
+            return [];
+        }
+
+        [$lower, $upper] = explode($separator, $rawRange, 2);
+
+        $lowerIsExclusive = str_starts_with(trim($lower), '[');
+        $upperIsExclusive = str_ends_with(trim($upper), ']');
+
+        $lower = $this->cleanBound($lower);
+        $upper = $this->cleanBound($upper);
+
+        // Both bounds empty is not a range; a present-but-non-numeric bound invalidates it.
+        if ($lower === '' && $upper === '') {
+            return [];
+        }
+        if (($lower !== '' && !is_numeric($lower)) || ($upper !== '' && !is_numeric($upper))) {
+            return [];
+        }
+
+        $range = [];
+
+        if ($lower !== '') {
+            $range[$lowerIsExclusive ? 'gt' : 'gte'] = $lower;
+        }
+        if ($upper !== '') {
+            $range[$upperIsExclusive ? 'lt' : 'lte'] = $upper;
+        }
+
+        return $range;
+    }
+
+    /**
+     * Bracket/brace/quote markers only ever wrap a bound, so they are stripped from the edges
+     * only: a bracket in the middle (e.g. '1[0') is not a marker, and leaving it in place lets
+     * the numeric guard in parseRange() reject the malformed bound.
+     */
+    protected function cleanBound(string $bound): string
+    {
+        return trim($bound, "[{]}' \t\n\r\0\x0B");
+    }
+}

--- a/src/Struct/Redirect.php
+++ b/src/Struct/Redirect.php
@@ -10,11 +10,17 @@ class Redirect extends Struct
 {
     public function __construct(
         protected readonly string $link,
+        protected readonly bool $permanent = true,
     ) {
     }
 
     public function getLink(): string
     {
         return $this->link;
+    }
+
+    public function isPermanent(): bool
+    {
+        return $this->permanent;
     }
 }

--- a/tests/Unit/Search/Request/Handler/CanonicalFilterUrlBuilderTest.php
+++ b/tests/Unit/Search/Request/Handler/CanonicalFilterUrlBuilderTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Tests\Unit\Search\Request\Handler;
+
+use Nosto\NostoIntegration\Search\Request\Handler\CanonicalFilterUrlBuilder;
+use Nosto\NostoIntegration\Struct\IdToFieldMapping;
+use PHPUnit\Framework\TestCase;
+
+final class CanonicalFilterUrlBuilderTest extends TestCase
+{
+    private function mapping(): IdToFieldMapping
+    {
+        return new IdToFieldMapping([
+            'facet-b' => 'brand',
+            'facet-c' => 'skus.customFields.colour',
+            'facet-p' => 'price',
+        ]);
+    }
+
+    private function build(?string $queryString, ?IdToFieldMapping $mapping = null): ?string
+    {
+        return (new CanonicalFilterUrlBuilder())->build(
+            '/search',
+            $queryString,
+            $mapping ?? $this->mapping(),
+        );
+    }
+
+    public function testRewritesValueFilterAndPreservesOtherParametersVerbatim(): void
+    {
+        self::assertSame(
+            '/search?search=main&facet-b=Shopware+Fashion',
+            $this->build('search=main&products.filter.brand=Shopware+Fashion'),
+        );
+    }
+
+    public function testConvertsDoublePipeToSinglePipe(): void
+    {
+        self::assertSame(
+            '/search?facet-c=Blue%7CRed',
+            $this->build('products.filter.skus.customFields.colour=Blue%7C%7CRed'),
+        );
+    }
+
+    public function testRangeBecomesMinAndMaxParameters(): void
+    {
+        self::assertSame(
+            '/search?min-facet-p=10&max-facet-p=20',
+            $this->build('products.filter.price=10%7E20'),
+        );
+    }
+
+    public function testOpenEndedRangeEmitsOnlyThePresentBound(): void
+    {
+        self::assertSame(
+            '/search?min-facet-p=10',
+            $this->build('products.filter.price=10%7E'),
+        );
+    }
+
+    public function testExclusiveRangeStillCanonicalises(): void
+    {
+        self::assertSame(
+            '/search?min-facet-p=10&max-facet-p=20',
+            $this->build('products.filter.price=%5B10%7E20%5D'),
+        );
+    }
+
+    public function testReturnsNullWithoutFieldPathParameters(): void
+    {
+        self::assertNull($this->build('search=main&sort=name-asc'));
+    }
+
+    public function testReturnsNullWithoutMapping(): void
+    {
+        self::assertNull(
+            (new CanonicalFilterUrlBuilder())->build(
+                '/search',
+                'search=main&products.filter.brand=Shopware+Fashion',
+                null,
+            ),
+        );
+    }
+
+    public function testReturnsNullWhenFieldDoesNotResolve(): void
+    {
+        self::assertNull($this->build('search=main&products.filter.unknownField=x'));
+    }
+
+    public function testKeepsUnresolvableFieldVerbatimBesideARewrittenOne(): void
+    {
+        self::assertSame(
+            '/search?products.filter.unknownField=x&facet-b=X',
+            $this->build('products.filter.unknownField=x&products.filter.brand=X'),
+        );
+    }
+
+    public function testOutputIsStableWhenFedBackIn(): void
+    {
+        $canonical = $this->build('search=main&products.filter.brand=Shopware+Fashion');
+
+        self::assertSame('/search?search=main&facet-b=Shopware+Fashion', $canonical);
+        self::assertNull($this->build('search=main&facet-b=Shopware+Fashion'));
+    }
+
+    public function testSortAndPaginationParametersKeepTheirPlace(): void
+    {
+        self::assertSame(
+            '/search?search=main&order=price-asc&p=2&facet-b=X',
+            $this->build('search=main&order=price-asc&p=2&products.filter.brand=X'),
+        );
+    }
+}

--- a/tests/Unit/Search/Request/Handler/FilterHandlerTest.php
+++ b/tests/Unit/Search/Request/Handler/FilterHandlerTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Tests\Unit\Search\Request\Handler;
+
+use Nosto\Model\Signup\Account;
+use Nosto\NostoIntegration\Search\Request\Handler\FilterHandler;
+use Nosto\NostoIntegration\Search\Response\GraphQL\Filter\LabelTextFilter;
+use Nosto\NostoIntegration\Service\FilterPayloadService;
+use Nosto\NostoIntegration\Struct\FiltersExtension;
+use Nosto\NostoIntegration\Struct\IdToFieldMapping;
+use Nosto\Operation\Search\SearchOperation;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Symfony\Component\HttpFoundation\Request;
+
+final class FilterHandlerTest extends TestCase
+{
+    private function handler(): FilterHandler
+    {
+        return new FilterHandler($this->createMock(FilterPayloadService::class));
+    }
+
+    private function searchOperation(): SearchOperation
+    {
+        return new SearchOperation(new Account('test-account'));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function appliedFilters(SearchOperation $operation): array
+    {
+        return $operation->getVariables()['filter'] ?? [];
+    }
+
+    public function testAppliesFieldPathValueFilterFromRealRequest(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?search=main&products.filter.brand=Shopware+Fashion');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'brand',
+                'value' => ['Shopware Fashion'],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testAppliesNestedSkuCustomFieldFilter(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.skus.customFields.colour=Blue%7C%7CRed');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'skus.customFields.colour',
+                'value' => ['Blue', 'Red'],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testAppliesRangeFilter(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.price=%5B10%7E20%5D');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'price',
+                'range' => [
+                    'gt' => '10',
+                    'lt' => '20',
+                ],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testIgnoresShopwareQueryParameters(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?search=main&sort=name-asc&p=2');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame([], $this->appliedFilters($operation));
+    }
+
+    public function testAppliesFieldPathFilterOnExistingRequestPath(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.brand=Shopware+Fashion');
+
+        // $newRequest = false is the cookie-backed path; the field-path filter must still
+        // apply even though no filter-mapping cookie is present.
+        $this->handler()->handleFilters($request, new Criteria(), $operation, false);
+
+        self::assertSame(
+            [[
+                'field' => 'brand',
+                'value' => ['Shopware Fashion'],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testAppliesOnlyTheFirstOfMultipleRanges(): void
+    {
+        // SearchOperation merges ranges per field, so only the first is representable.
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.price=10%7E20,30%7E40');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'price',
+                'range' => [
+                    'gt' => '10',
+                    'lt' => '20',
+                ],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testRoutesRatingFieldToARangeFilter(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.ratingValue=4');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'ratingValue',
+                'range' => [
+                    'gt' => '4',
+                ],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testKeepsTheFirstRangeWhenAFieldIsRepeated(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.price=10%7E20&products.filter.price=30%7E40');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'price',
+                'range' => [
+                    'gt' => '10',
+                    'lt' => '20',
+                ],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testAppliesFieldPathFilterWithNoFacetMapping(): void
+    {
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.brand=Shopware+Fashion');
+
+        $this->handler()->handleFilters($request, new Criteria(), $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'brand',
+                'value' => ['Shopware Fashion'],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testFieldPathOnlyRequestSkipsTheCookiePayloadLookup(): void
+    {
+        // This is what withoutFieldPathParameters() actually buys. PHP also exposes each
+        // field-path parameter under a mangled 'products_filter_*' name; if those were left in
+        // $selectedFilters, a request carrying only field-path filters would not take the early
+        // return and would pay a cookie-payload lookup (a DB read) it has no use for.
+        $payloadService = $this->createMock(FilterPayloadService::class);
+        $payloadService->expects(self::never())->method('resolveCookiePayload');
+
+        $operation = $this->searchOperation();
+        $request = Request::create('/search?products.filter.brand=Shopware+Fashion');
+
+        // $newRequest = false is the cookie-backed path, the only one that reads the payload.
+        (new FilterHandler($payloadService))->handleFilters($request, new Criteria(), $operation, false);
+
+        // The filter itself must still be applied exactly once.
+        self::assertSame(
+            [[
+                'field' => 'brand',
+                'value' => ['Shopware Fashion'],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testAppliesEachSourceOnceOnALiveSerpShapedRequest(): void
+    {
+        // On a live SERP the facet is in the 'nostoFilters' extension and mapped to the same
+        // field a field-path parameter targets. Both sources must contribute exactly once.
+        $operation = $this->searchOperation();
+
+        $criteria = new Criteria();
+        $criteria->addExtension('nostoFilterMapping', new IdToFieldMapping([
+            'facet-123' => 'brand',
+        ]));
+        $criteria->addExtension('nostoFilters', (new FiltersExtension())->addFilter(
+            new LabelTextFilter('facet-123', 'Brand', 'brand'),
+        ));
+
+        $request = Request::create(
+            '/search?facet-123=Shopware+Freetime&products.filter.brand=Shopware+Fashion',
+        );
+
+        $this->handler()->handleFilters($request, $criteria, $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'brand',
+                'value' => ['Shopware Fashion', 'Shopware Freetime'],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+
+    public function testAppliesEachSourceOnceWhenBothAFacetIdAndAFieldPathArePresent(): void
+    {
+        // A facet-id parameter and a field-path parameter for the same field must each
+        // contribute exactly one value: two distinct sources, no duplication of either.
+        $operation = $this->searchOperation();
+
+        $criteria = new Criteria();
+        $criteria->addExtension('nostoFilterMapping', new IdToFieldMapping([
+            'facet-123' => 'brand',
+        ]));
+        $criteria->addExtension('nostoFilters', (new FiltersExtension())->addFilter(
+            new LabelTextFilter('facet-123', 'Brand', 'brand'),
+        ));
+
+        $request = Request::create('/search?facet-123=Shopware+Freetime&products.filter.brand=Shopware+Fashion');
+
+        $this->handler()->handleFilters($request, $criteria, $operation);
+
+        self::assertSame(
+            [[
+                'field' => 'brand',
+                'value' => ['Shopware Fashion', 'Shopware Freetime'],
+            ]],
+            $this->appliedFilters($operation),
+        );
+    }
+}

--- a/tests/Unit/Search/Request/Handler/NostoFieldFilterParserTest.php
+++ b/tests/Unit/Search/Request/Handler/NostoFieldFilterParserTest.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nosto\NostoIntegration\Tests\Unit\Search\Request\Handler;
+
+use Nosto\NostoIntegration\Search\Request\Handler\NostoFieldFilterParser;
+use PHPUnit\Framework\TestCase;
+
+final class NostoFieldFilterParserTest extends TestCase
+{
+    public function testRecognisesPrefixedParameter(): void
+    {
+        self::assertTrue(NostoFieldFilterParser::supports('products.filter.brand'));
+    }
+
+    public function testIgnoresShopwareParameters(): void
+    {
+        self::assertFalse(NostoFieldFilterParser::supports('q'));
+        self::assertFalse(NostoFieldFilterParser::supports('sort'));
+        self::assertFalse(NostoFieldFilterParser::supports('p'));
+        self::assertFalse(NostoFieldFilterParser::supports('68836248ec4277760d058e18'));
+        self::assertFalse(NostoFieldFilterParser::supports('min-price'));
+    }
+
+    public function testExtractsSimpleField(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.brand', 'Nosto');
+
+        self::assertNotNull($filter);
+        self::assertSame('brand', $filter->field);
+        self::assertSame(['Nosto'], $filter->values);
+        self::assertFalse($filter->isRange());
+    }
+
+    public function testExtractsNestedSkuCustomField(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse(
+            'products.filter.skus.customFields.größe',
+            '100x200cm',
+        );
+
+        self::assertNotNull($filter);
+        self::assertSame('skus.customFields.größe', $filter->field);
+        self::assertSame(['100x200cm'], $filter->values);
+    }
+
+    public function testReturnsNullForUnprefixedKey(): void
+    {
+        self::assertNull((new NostoFieldFilterParser())->parse('brand', 'Nosto'));
+    }
+
+    public function testReturnsNullForEmptyFieldOrValue(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        self::assertNull($parser->parse('products.filter.', 'Nosto'));
+        self::assertNull($parser->parse('products.filter.brand', ''));
+    }
+
+    public function testRejectsFieldWithControlCharacters(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        self::assertNull($parser->parse("products.filter.\0nul", '1'));
+        self::assertNull($parser->parse("products.filter.a\tb", '1'));
+        self::assertNull($parser->parse('products.filter.a"b', '1'));
+        self::assertNull($parser->parse('products.filter.a{b}', '1'));
+    }
+
+    public function testRejectsOverlongFieldName(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        self::assertNotNull($parser->parse('products.filter.' . str_repeat('a', 128), '1'));
+        self::assertNull($parser->parse('products.filter.' . str_repeat('a', 129), '1'));
+    }
+
+    public function testAcceptsLocalisedAndNestedFieldNames(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        self::assertSame(
+            'skus.customFields.größe',
+            $parser->parse('products.filter.skus.customFields.größe', '1')?->field,
+        );
+        self::assertSame('brand', $parser->parse('products.filter.brand', '1')?->field);
+        self::assertSame('custom field', $parser->parse('products.filter.custom field', '1')?->field);
+        self::assertSame('size-eu', $parser->parse('products.filter.size-eu', '1')?->field);
+        self::assertSame('size.eu', $parser->parse('products.filter.size::eu', '1')?->field);
+    }
+
+    public function testSplitsMultipleValuesOnDoublePipe(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse(
+            'products.filter.skus.customFields.colour',
+            'Blue||Red||White',
+        );
+
+        self::assertNotNull($filter);
+        self::assertSame(['Blue', 'Red', 'White'], $filter->values);
+    }
+
+    public function testDoesNotSplitOnSinglePipe(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.brand', 'A|B');
+
+        self::assertNotNull($filter);
+        self::assertSame(['A|B'], $filter->values);
+    }
+
+    public function testUnescapesEncodedTildeInValues(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.brand', 'A%7EB');
+
+        self::assertNotNull($filter);
+        self::assertSame(['A~B'], $filter->values);
+    }
+
+    public function testDropsEmptySegmentsFromMultiValue(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.brand', 'A||||B');
+
+        self::assertNotNull($filter);
+        self::assertSame(['A', 'B'], $filter->values);
+    }
+
+    public function testParsesInclusiveRange(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.price', '10~20');
+
+        self::assertNotNull($filter);
+        self::assertTrue($filter->isRange());
+        self::assertSame([[
+            'gte' => '10',
+            'lte' => '20',
+        ]], $filter->ranges);
+        self::assertSame([], $filter->values);
+    }
+
+    public function testParsesOpenEndedRanges(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        self::assertSame([[
+            'gte' => '10',
+        ]], $parser->parse('products.filter.price', '10~')->ranges);
+        self::assertSame([[
+            'lte' => '20',
+        ]], $parser->parse('products.filter.price', '~20')->ranges);
+    }
+
+    public function testParsesExclusiveBoundsFromBrackets(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.price', '[10~20]');
+
+        self::assertNotNull($filter);
+        self::assertSame([[
+            'gt' => '10',
+            'lt' => '20',
+        ]], $filter->ranges);
+    }
+
+    public function testParsesMultipleCommaSeparatedRanges(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.price', '10~20,30~40');
+
+        self::assertNotNull($filter);
+        self::assertSame(
+            [[
+                'gte' => '10',
+                'lte' => '20',
+            ], [
+                'gte' => '30',
+                'lte' => '40',
+            ]],
+            $filter->ranges,
+        );
+    }
+
+    public function testParsesLegacyRangeSeparator(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.price', '10-+20');
+
+        self::assertNotNull($filter);
+        self::assertSame([[
+            'gte' => '10',
+            'lte' => '20',
+        ]], $filter->ranges);
+    }
+
+    public function testEscapedTildeIsAValueNotARange(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.brand', 'A%7EB');
+
+        self::assertNotNull($filter);
+        self::assertFalse($filter->isRange());
+        self::assertSame(['A~B'], $filter->values);
+    }
+
+    public function testBareValueWithNoSeparatorIsNotARange(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.brand', '100x200cm');
+
+        self::assertNotNull($filter);
+        self::assertFalse($filter->isRange());
+        self::assertSame(['100x200cm'], $filter->values);
+    }
+
+    public function testUnescapesDoubleColonInFieldSegments(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.size::eu', '42');
+
+        self::assertNotNull($filter);
+        self::assertSame('size.eu', $filter->field);
+    }
+
+    public function testLeavesNestedPathSeparatorsIntact(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse(
+            'products.filter.skus.customFields.größe',
+            '100x200cm',
+        );
+
+        self::assertNotNull($filter);
+        self::assertSame('skus.customFields.größe', $filter->field);
+    }
+
+    public function testParsesFieldPathFiltersFromRawQueryString(): void
+    {
+        // Exactly what Nosto's search-js puts on the wire: dots unencoded, '||' as %7C%7C,
+        // range separator as %7E, and a literal tilde double-encoded as %257E.
+        $queryString = 'search=main'
+            . '&products.filter.brand=A%257EB'
+            . '&products.filter.colour=Blue%7C%7CRed'
+            . '&products.filter.price=10%7E20'
+            . '&products.filter.skus.customFields.gr%C3%B6%C3%9Fe=140x200cm'
+            . '&products.filter.legacy=10-%2B20'
+            . '&products.filter.name=Blue+Steel';
+
+        $filters = (new NostoFieldFilterParser())->parseQueryString($queryString);
+
+        self::assertCount(6, $filters);
+
+        self::assertSame('brand', $filters[0]->field);
+        self::assertSame(['A~B'], $filters[0]->values);
+        self::assertFalse($filters[0]->isRange());
+
+        self::assertSame('colour', $filters[1]->field);
+        self::assertSame(['Blue', 'Red'], $filters[1]->values);
+
+        self::assertSame('price', $filters[2]->field);
+        self::assertSame([[
+            'gte' => '10',
+            'lte' => '20',
+        ]], $filters[2]->ranges);
+
+        self::assertSame('skus.customFields.größe', $filters[3]->field);
+        self::assertSame(['140x200cm'], $filters[3]->values);
+
+        // The legacy '-+' separator arrives form-urlencoded as '10-%2B20'.
+        self::assertSame('legacy', $filters[4]->field);
+        self::assertSame([[
+            'gte' => '10',
+            'lte' => '20',
+        ]], $filters[4]->ranges);
+
+        // Form-urlencoding puts a space on the wire as '+', so urldecode (not rawurldecode)
+        // is what restores it.
+        self::assertSame('name', $filters[5]->field);
+        self::assertSame(['Blue Steel'], $filters[5]->values);
+    }
+
+    public function testParseQueryStringIgnoresNonNostoParameters(): void
+    {
+        $filters = (new NostoFieldFilterParser())->parseQueryString('search=main&sort=name-asc&p=2');
+
+        self::assertSame([], $filters);
+    }
+
+    public function testParseQueryStringHandlesEmptyAndNullInput(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        self::assertSame([], $parser->parseQueryString(null));
+        self::assertSame([], $parser->parseQueryString(''));
+        self::assertSame([], $parser->parseQueryString('&&'));
+    }
+
+    public function testParseQueryStringSkipsValuelessParameter(): void
+    {
+        $filters = (new NostoFieldFilterParser())->parseQueryString('products.filter.brand');
+
+        self::assertSame([], $filters);
+    }
+
+    public function testRejectsNonNumericRangeBoundsAndFallsBackToValue(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        // A value delimiter inside what looks like a range means it is not a range.
+        $filter = $parser->parse('products.filter.brand', '10~20||30');
+        self::assertNotNull($filter);
+        self::assertFalse($filter->isRange());
+        self::assertSame(['10~20', '30'], $filter->values);
+
+        // Non-numeric bounds are not a range either.
+        $filter = $parser->parse('products.filter.brand', 'abc~def');
+        self::assertNotNull($filter);
+        self::assertFalse($filter->isRange());
+        self::assertSame(['abc~def'], $filter->values);
+    }
+
+    public function testTrimsNumericRangeBounds(): void
+    {
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.price', ' 10 ~ 20 ');
+
+        self::assertNotNull($filter);
+        self::assertTrue($filter->isRange());
+        self::assertSame([[
+            'gte' => '10',
+            'lte' => '20',
+        ]], $filter->ranges);
+    }
+
+    public function testDetectsExclusiveBoundsOnlyAtTheEdges(): void
+    {
+        // A bracket in the middle of a bound is not an exclusivity marker; the bound is
+        // then non-numeric, so this is a value rather than a range.
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.price', '1[0~20');
+
+        self::assertNotNull($filter);
+        self::assertFalse($filter->isRange());
+    }
+
+    public function testIgnoresEmptyCommaSegmentsInRanges(): void
+    {
+        $parser = new NostoFieldFilterParser();
+
+        // A stray comma carries no information and must not invalidate the range. Degrading
+        // to a terms filter here would search for the literal string and match nothing.
+        foreach (['10~20,', ',10~20'] as $rawValue) {
+            $filter = $parser->parse('products.filter.price', $rawValue);
+            self::assertNotNull($filter, $rawValue);
+            self::assertTrue($filter->isRange(), $rawValue);
+            self::assertSame([[
+                'gte' => '10',
+                'lte' => '20',
+            ]], $filter->ranges, $rawValue);
+        }
+
+        foreach (['10~20,,30~40', '10~20,30~40,'] as $rawValue) {
+            $filter = $parser->parse('products.filter.price', $rawValue);
+            self::assertNotNull($filter, $rawValue);
+            self::assertSame(
+                [[
+                    'gte' => '10',
+                    'lte' => '20',
+                ], [
+                    'gte' => '30',
+                    'lte' => '40',
+                ]],
+                $filter->ranges,
+                $rawValue,
+            );
+        }
+    }
+
+    public function testStillRejectsNonEmptyGarbageSegments(): void
+    {
+        // Non-empty unparseable segments must still invalidate the whole parameter.
+        $filter = (new NostoFieldFilterParser())->parse('products.filter.price', '10~20,abc~def');
+
+        self::assertNotNull($filter);
+        self::assertFalse($filter->isRange());
+        self::assertSame(['10~20,abc~def'], $filter->values);
+    }
+}


### PR DESCRIPTION
[ADS-5261](https://nostosolutions.atlassian.net/browse/ADS-5261)

### The problem
Merchants can configure keyword facets in Nosto, so typing "matra" in search suggests "matratze in 140x200cm". Clicking that suggestion sends the shopper to a URL where the filter is named the Nosto way:

/search?search=matratze&products.filter.skus.customFields.größe=140x200cm

Our plugin only recognised filters named the Shopware way - by facet id - so it ignored the parameter entirely. The shopper asked for 140x200 and got every mattress.

Merchants have been working around this by hand-maintaining a serpUrlMapping in their Nosto search templates, mapping each field to a hardcoded facet id, per domain. matratzen-concord.de does exactly this. It doesn't scale and it breaks whenever a facet is recreated.

### What this does
Teaches the plugin to read Nosto's format and translate it to Shopware's:

Reads products.filter. parameters and applies them to the Nosto search request - so the filter works immediately, on search and category pages.
Translates the field name to its facet id and redirects to the tidy URL, so the filter panel shows the filter as selected, its "×" removes it, and Shopware's listing JS stops dropping it when the shopper changes sorting or page.
The translation is derived from Nosto's own response, so serpUrlMapping is no longer needed by anyone.

### How to test
Enable Nosto search for a sales channel with at least one facet configured.
Search for something, then append a field-path filter, e.g. ?search=main&products.filter.brand=Acme
You should be redirected to ?search=main&=Acme, with fewer results and the filter ticked in the sidebar.
Change the sorting - the filter should stay applied.
Verified on a test store: unfiltered search returns 3 products, products.filter.brand=Shopware Fashion returns 1. Same on a category page (2 → 1). Ranges become min-/max-; multi-value converts Nosto's || to Shopware's |.

[ADS-5261]: https://nostosolutions.atlassian.net/browse/ADS-5261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ